### PR TITLE
Add optimizations from HeadsUp.EnemyHud to this EnemyHud.

### DIFF
--- a/BetterUI/BetterUI.csproj
+++ b/BetterUI/BetterUI.csproj
@@ -10,9 +10,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BetterUI</RootNamespace>
     <AssemblyName>BetterUI</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <LangVersion>9</LangVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>none</DebugType>

--- a/BetterUI/Main.cs
+++ b/BetterUI/Main.cs
@@ -16,7 +16,7 @@ namespace BetterUI
           MODNAME = "BetterUI",
           AUTHOR = "MK",
           GUID = AUTHOR + "_" + MODNAME,
-          VERSION = "2.1.0";
+          VERSION = "2.2.0";
 
         internal static ManualLogSource log;
         internal readonly Harmony harmony;


### PR DESCRIPTION
**Note**
  * Updated the `TargetFrameworkVersion` to `v4.8`.
  * Updated the `LangVersion` to `9`.
  * Updated the mod version number to `v2.2.0`.

  * Modify ShowHud.Prefix() and use the __state variable to store if the Hud already exists.
    * This removes the need to reimplement the entire ShowHud code in the original BetterUI prefix patch and instead simplify it to a Postfix patch.
  * Use a ConditionalWeakTable to cache generated Unity.Text HpText objects to their EnemyHud.HudData keys.
    * This removes the cost calls to traverse the UI transform tree to find the HpText object to modify.
  * Add a transpiler to the EnemyHud.LateUpdate() that will show the local player's Hud (instead of it being hidden).
    * TODO: add a separate config value to toggle this on/off itself instead of reusing the `showPlayerHPText` config.