### PR TITLE
Color of the item movement speed tooltip is now set correctly

### DIFF
--- a/BetterUI/Patches/Items.cs
+++ b/BetterUI/Patches/Items.cs
@@ -201,7 +201,7 @@ namespace BetterUI.Patches
       sb.Append("\n" + new string('\u2500', 10) + "  Buffs  " + new string('\u2500', 10));
       if (player.m_equipmentMovementModifier != 0f)
       {
-        string color = player.m_equipmentMovementModifier > 0 ? "green" : "red";
+        string color = player.m_equipmentMovementModifier >= 0 ? "green" : "red";
         sb.AppendFormat("\nMovement: <color={0}>{1}%</color>", color, player.m_equipmentMovementModifier * 100f);
       }
 
@@ -510,8 +510,7 @@ namespace BetterUI.Patches
 
     private static void Movement(Player localPlayer)
     {
-      //float equipmentMovementModifier = localPlayer.GetEquipmentMovementModifier();
-      string color = localPlayer.m_equipmentMovementModifier > 0 ? "green" : "red";
+      string color = _item.m_shared.m_movementModifier >= 0 ? "green" : "red";
       _sb.AppendFormat("\n$item_movement_modifier: <color={0}>{1}%</color>", color, (_item.m_shared.m_movementModifier * 100f).ToString("+0;-0"));
     }
 

--- a/BetterUI/Patches/Items.cs
+++ b/BetterUI/Patches/Items.cs
@@ -508,7 +508,7 @@ namespace BetterUI.Patches
       }
     }
 
-    private static void Movement(Player localPlayer)
+    private static void Movement()
     {
       string color = _item.m_shared.m_movementModifier >= 0 ? "green" : "red";
       _sb.AppendFormat("\n$item_movement_modifier: <color={0}>{1}%</color>", color, (_item.m_shared.m_movementModifier * 100f).ToString("+0;-0"));
@@ -748,7 +748,7 @@ namespace BetterUI.Patches
         _sb.Append("\n");
       }
 
-      if (_item.m_shared.m_movementModifier != 0f && localPlayer != null) Movement(localPlayer);
+      if (_item.m_shared.m_movementModifier != 0f) Movement();
 
       DamageModifiers();
 
@@ -783,7 +783,7 @@ namespace BetterUI.Patches
           _sb.Append("\n");
         }
 
-        if (_item.m_shared.m_movementModifier != 0f && localPlayer != null) Movement(localPlayer);
+        if (_item.m_shared.m_movementModifier != 0f) Movement();
 
         DamageModifiers();
 

--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ I'll add slowly new additions to the mod - and fix bugs that users report.
 [/Package](/BetterUI/Package) - Package for Thunderstore upload.  
 
 ## Developing environment
+#### Game Directory
+- If your valheim game directory is not the standard windows location `C:\Program Files (x86)\Steam\steamapps\common\Valheim`, edit [GameDir.targets](/BetterUI/GameDir.targets) accordingly
+- Remember to not stage and commit any changes to `GameDir.targets`
 #### BepInEx
  - Download and install [BepInEx](https://valheim.thunderstore.io/package/denikson/BepInExPack_Valheim/) *(this is an Valheim specific pack)*
  - Follow the information under manual install
 #### BepInEx Publicizer
- - To get access on games private functions, you need the publicized assembly files.
+ - To get access on games private functions, you need the publicized assembly files
  - Install an assembly publicizer for BepInEx from:  https://github.com/MrPurple6411/Bepinex-Tools/releases/tag/1.0.0-Publicizer
  - The `Bepinex-Publicizer` folder from the `.zip` should be placed under `<ValheimGameDirectory>\BepInEx\plugins`
  - Run the game once, BepInEx console should pop-up. At the background, BepInEx Publicizer will create assemblies  


### PR DESCRIPTION
The color of any item movement tooltip was not based on its value, but instead based on the current player movement speed modifier. So equipping Fenris armor would turn all negative movement speed tooltips green instead of red. This bug existed since the original Better UI version by MKMasa.

A null check in line 513 is not needed as it was accessed without a null check in line 514 just fine. The multiplication by 100 is not needed to determine whether the color needs to be green or red.

I also adjusted readme build instructions to mention the $GameDir variable for people who don't have steam/ valheim installed on the C drive.