### PR TITLE
Rewritten how bars work to fix current issues, added new mistlands resource bar

### DIFF
--- a/BetterUI/GameClasses/Skills.cs
+++ b/BetterUI/GameClasses/Skills.cs
@@ -25,10 +25,8 @@ namespace BetterUI.GameClasses
             [HarmonyPatch(typeof(Skills.Skill), "Raise")]
             private static void CalculateXP(ref Skills __instance, float factor)
             {
-                //if (BetterHud._bar == null) return;
-
                 Patches.XP.RaiseXP();
-                if (Main.showCharacterXpBar.Value) BetterHud._bar.SetValue(Patches.XP.LevelProgressPercentage);
+                Patches.XPBar.UpdateLevelProgressPercentage();
             }
         }
     }

--- a/BetterUI/Main.cs
+++ b/BetterUI/Main.cs
@@ -33,10 +33,12 @@ namespace BetterUI
         public static ConfigEntry<KeyCode> modKeySecondary;
         public static ConfigEntry<bool> useCustomHealthBar;
         public static ConfigEntry<bool> useCustomStaminaBar;
+        public static ConfigEntry<bool> useCustomSpoilerBar;
         public static ConfigEntry<bool> useCustomFoodBar;
-        public static ConfigEntry<int> healthBarRotation;
-        public static ConfigEntry<int> staminaBarRotation;
-        public static ConfigEntry<int> foodBarRotation;
+        public static ConfigEntry<int> customHealthBarRotation;
+        public static ConfigEntry<int> customStaminaBarRotation;
+        public static ConfigEntry<int> customSpoilerBarRotation;
+        public static ConfigEntry<int> customFoodBarRotation;
 
         // Player Inventory
         public static ConfigEntry<bool> showDurabilityColor;
@@ -98,146 +100,152 @@ namespace BetterUI
         }
         public void Awake()
         {
+            string sectionName;
+
+            // Don't be tempted to rename the sections. That resets all its config values for every user
+            // The same goes for moving items between sections
+            // That's also why there is no section number counter
+
+
             // Player HUD
-            enablePlayerHudEditing = Config.Bind("1 - Player HUD", nameof(enablePlayerHudEditing), true, "Enable the ability to edit the Player HUD by pressing a hotkey. (REQUIRES RESTART)");
+            sectionName = "1 - Player HUD";
 
-            togglePlayerHudEditModeKey = Config.Bind("1 - Player HUD", nameof(togglePlayerHudEditModeKey), KeyCode.F7, "Key used to toggle Player HUD editing mode.");
+            togglePlayerHudEditModeKey = Config.Bind(sectionName, nameof(togglePlayerHudEditModeKey), KeyCode.F7,
+                "Key used to toggle Player HUD editing mode. Accepted values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
 
-            modKeyPrimary = Config.Bind("1 - Player HUD", nameof( modKeyPrimary), KeyCode.Mouse0,
-              "Button needed to hold down to change HUD position. Accepted values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
+            modKeyPrimary = Config.Bind(sectionName, nameof(modKeyPrimary), KeyCode.Mouse0,
+                "Key needed to hold down to change HUD position. Accepted values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
 
-            modKeySecondary = Config.Bind("1 - Player HUD", nameof(modKeySecondary), KeyCode.LeftControl,
-              "Button needed to hold down to change element dimensions. Accepted Values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
+            modKeySecondary = Config.Bind(sectionName, nameof(modKeySecondary), KeyCode.LeftControl,
+                "Key needed to hold down to change element dimensions. Accepted Values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
 
-            useCustomHealthBar = Config.Bind("1 - Player HUD", nameof(useCustomHealthBar), false, "Resizable, rotatable HP bar. This bar will always be the same size and will not scale when you eat. (REQUIRES RESTART)");
+            // Player HUD RESTART
+            sectionName = "1 - Player HUD (Requires Logout)";
+
+            enablePlayerHudEditing = Config.Bind(sectionName, nameof(enablePlayerHudEditing), true, "Enable the ability to edit the Player HUD by pressing a hotkey.");
+
+            useCustomHealthBar = Config.Bind(sectionName, nameof(useCustomHealthBar), false, $"Resizable, rotatable HP bar. This bar will always be the same size and will not scale when you eat. Will also disable the default food bar, so use {nameof(useCustomFoodBar)}.");
             
-            useCustomStaminaBar = Config.Bind("1 - Player HUD", nameof(useCustomStaminaBar), false, "Resizable, rotatable Stamina bar. This bar will always be visible and will not scale when you eat. (REQUIRES RESTART)");
-            
-            useCustomFoodBar = Config.Bind("1 - Player HUD", nameof(useCustomFoodBar), false, "Resizable, rotatable Food Bar. (REQUIRES RESTART)");
+            useCustomStaminaBar = Config.Bind(sectionName, nameof(useCustomStaminaBar), false, "Resizable, rotatable Stamina bar. This bar will always be visible and will not scale when you eat.");
 
-            healthBarRotation = Config.Bind("1 - Player HUD", nameof(healthBarRotation), 0, "Rotate healthbar in degrees  (REQUIRES RESTART)");
+            useCustomSpoilerBar = Config.Bind(sectionName, nameof(useCustomSpoilerBar), false, "Resizable, rotatable bar for the new spoiler resource. This bar will always be visible and will not scale when you eat.");
 
-            staminaBarRotation = Config.Bind("1 - Player HUD", nameof(staminaBarRotation), 90, "Rotate staminabar in degrees  (REQUIRES RESTART)");
+            useCustomFoodBar = Config.Bind(sectionName, nameof(useCustomFoodBar), false, $"Resizable, rotatable Food Bar. Requires {nameof(useCustomHealthBar)}.");
 
-            foodBarRotation = Config.Bind("1 - Player HUD", nameof(foodBarRotation), 90, "Rotate foodbar in degrees  (REQUIRES RESTART)" +
-                "" +
-                "");
-            
+            customHealthBarRotation = Config.Bind(sectionName, nameof(customHealthBarRotation), 90, "Rotate healthbar in degrees.");
+
+            customStaminaBarRotation = Config.Bind(sectionName, nameof(customStaminaBarRotation), 90, "Rotate staminabar in degrees.");
+
+            customSpoilerBarRotation = Config.Bind(sectionName, nameof(customSpoilerBarRotation), 90, "Rotate bar for the new spoiler resource in degrees.");
+
+            customFoodBarRotation = Config.Bind(sectionName, nameof(customFoodBarRotation), 90, "Rotate foodbar in degrees.");
+
 
             // Character Inventory
-            showDurabilityColor = Config.Bind("2 - Character Inventory", nameof(showDurabilityColor), true, "Show colored durability bars for items");
+            sectionName = "2 - Character Inventory";
 
-            durabilityColorPalette = Config.Bind("2 - Character Inventory", nameof(durabilityColorPalette), 0, "Change Durabilty bar colors. Options: 0=Green,Yellow,Orange,Red, 1=White,Light Yellow,Light Cyan,Blue. ");
+            showDurabilityColor = Config.Bind(sectionName, nameof(showDurabilityColor), true, "Show colored durability bars for items.");
 
-            showItemStars = Config.Bind("2 - Character Inventory", nameof(showItemStars), true, "Show item quality as stars");
+            durabilityColorPalette = Config.Bind(sectionName, nameof(durabilityColorPalette), 0, "Change Durabilty bar colors. Options: 0 = Green, Yellow, Orange, Red, 1 = White, Light Yellow, Light Cyan, Blue.");
 
-            showCustomCharInfo = Config.Bind("2 - Character Inventory", nameof(showCustomCharInfo), true, "Show Kills, Deaths, Builds, and Crafts stats on character selection screen");
+            showItemStars = Config.Bind(sectionName, nameof(showItemStars), true, "Show item quality as stars.");
 
-            showCustomTooltips = Config.Bind("2 - Character Inventory", nameof(showCustomTooltips), true, "Show more info on inventory item tooltips. Disable this is using Epic Loot.");
+            showCustomCharInfo = Config.Bind(sectionName, nameof(showCustomCharInfo), true, "Show Deaths, Builds, and Crafts stats on character selection screen. Also shows the Kills stat if something increases it.");
 
-            showCombinedItemStats = Config.Bind("2 - Character Inventory", nameof(showCombinedItemStats), true, "Show all item stats when mouse is hovered over armor amount.");
+            showCustomTooltips = Config.Bind(sectionName, nameof(showCustomTooltips), true, "Show more info on inventory item tooltips. Disable this is using Epic Loot.");
 
-            iconScaleSize = Config.Bind("2 - Character Inventory", nameof(iconScaleSize), 0.75f, "Scale item icon by this factor. Ex. 0.75 makes them 75% of original size");
+            showCombinedItemStats = Config.Bind(sectionName, nameof(showCombinedItemStats), true, "Show all item stats when mouse is hovered over armor amount.");
+
+            iconScaleSize = Config.Bind(sectionName, nameof(iconScaleSize), 0.75f, "Scale item icon by this factor. Ex. 0.75 makes them 75% of original size.");
 
 
             // Skills UI
-            customSkillUI = Config.Bind("3 - Character Skills", nameof(customSkillUI), false, "Toggle the use of custom skills UI");
+            sectionName = "3 - Character Skills";
 
-            skillUITextSize = Config.Bind("3 - Character Skills", nameof(skillUITextSize), 14, "Select text size on skills UI");
+            customSkillUI = Config.Bind(sectionName, nameof(customSkillUI), false, "Toggle the use of custom skills UI.");
+
+            skillUITextSize = Config.Bind(sectionName, nameof(skillUITextSize), 14, "Select text size on skills UI.");
 
 
             // Hover Text
-            timeLeftStyleFermenter = Config.Bind("4 - Hover Text", nameof(timeLeftStyleFermenter), 2, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left");
+            sectionName = "4 - Hover Text";
 
-            timeLeftStylePlant = Config.Bind("4 - Hover Text", nameof(timeLeftStylePlant), 2, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left");
+            timeLeftStyleFermenter = Config.Bind(sectionName, nameof(timeLeftStyleFermenter), 2, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left.");
 
-            timeLeftStyleCookingStation = Config.Bind("4 - Hover Text", nameof(timeLeftStyleCookingStation), 2, "Select duration display. 0 = Default, 1= % Done, 2 = min:sec left");
+            timeLeftStylePlant = Config.Bind(sectionName, nameof(timeLeftStylePlant), 2, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left.");
 
-            chestHasRoomStyle = Config.Bind("4 - Hover Text", nameof(chestHasRoomStyle), 2, "Select how chest emptyness is displayed. 0 = Default | 1 = % | 2 = items / max_room. | 3 = free slots ");
+            timeLeftStyleCookingStation = Config.Bind(sectionName, nameof(timeLeftStyleCookingStation), 2, "Select duration display. 0 = Default, 1= % Done, 2 = min:sec left.");
+
+            chestHasRoomStyle = Config.Bind(sectionName, nameof(chestHasRoomStyle), 2, "Select how chest emptyness is displayed. 0 = Default | 1 = % | 2 = items / max_room. | 3 = free slots.");
 
 
             // Character XP
-            showCharacterXP = Config.Bind("5 - Character XP", nameof(showCharacterXP), true, "Enable Character XP. This combines all skill levels to show overall character progress.");
+            sectionName = "5 - Character XP";
 
-            showCharacterXpBar = Config.Bind("5 - Character XP", nameof(showCharacterXpBar), true, "Show Character XP Bar on the bottom of the screen. Character XP must be enabled.");
+            showCharacterXP = Config.Bind(sectionName, nameof(showCharacterXP), true, "Enable Character XP. This combines all skill levels to show overall character progress.");
 
-            showCharacterXpBar.Value = showCharacterXP.Value && showCharacterXpBar.Value;
+            showXPNotifications = Config.Bind(sectionName, nameof(showXPNotifications), true, "Show whenever you gain xp from actions.");
 
-            showXPNotifications = Config.Bind("5 - Character XP", nameof(showXPNotifications), true, "Show whenever you gain xp from actions.");
+            notificationTextSizeXP = Config.Bind(sectionName, nameof(notificationTextSizeXP), 14, "XP notification font size.");
 
-            notificationTextSizeXP = Config.Bind("5 - Character XP", nameof(notificationTextSizeXP), 14, "XP notification font size.");
+            extendedXPNotification = Config.Bind(sectionName, nameof(extendedXPNotification), true, "Extend notification with: (xp gained) [current/overall xp].");
 
-            extendedXPNotification = Config.Bind("5 - Character XP", nameof(extendedXPNotification), true, "Extend notification with: (xp gained) [current/overall xp]");
+            // Character XP RESTART
+            sectionName = "5 - Character XP (Requires Logout)";
+
+            showCharacterXpBar = Config.Bind(sectionName, nameof(showCharacterXpBar), true, "Show Character XP Bar on the bottom of the screen. Character XP must be enabled.");
 
 
             // Enemy HUD
-            customEnemyHud = Config.Bind("6 - Enemy HUD", nameof(customEnemyHud), true, "Enable custom enemy HUD changes. If this is set to false, all options in this section will be disabled.");
+            sectionName = "6 - Enemy HUD";
 
-            useCustomAlertedStatus = Config.Bind("6 - Enemy HUD", nameof(useCustomAlertedStatus), true, "Hide the vanilla alerted icons above the enemy health bar and instead change the color of the name based on the alerted status.");
+            customEnemyHud = Config.Bind(sectionName, nameof(customEnemyHud), true, "Enable custom enemy HUD changes. If this is set to false, all options in this section will be disabled.");
 
-            showEnemyHPText = Config.Bind("6 - Enemy HUD", nameof(showEnemyHPText), true, "Show the text with HP amount on enemies health bar.");
+            useCustomAlertedStatus = Config.Bind(sectionName, nameof(useCustomAlertedStatus), true, "Hide the vanilla alerted icons above the enemy health bar and instead change the color of the name based on the alerted status.");
 
-            enemyLvlStyle = Config.Bind("6 - Enemy HUD", nameof(enemyLvlStyle), 0, "Choose how enemy lvl is shown. 0 = Default(stars) | 1 = Prefix before name (Lv. 1) | 2 = Both");
+            showEnemyHPText = Config.Bind(sectionName, nameof(showEnemyHPText), true, "Show the text with HP amount on enemies health bar.");
 
-            enemyNameTextSize = Config.Bind("6 - Enemy HUD", nameof(enemyNameTextSize), 14, "Font Size of the Name on the enemy");
+            enemyLvlStyle = Config.Bind(sectionName, nameof(enemyLvlStyle), 0, "Choose how enemy lvl is shown. 0 = Default (stars) | 1 = Prefix before name (Lv. 1) | 2 = Both.");
 
-            enemyHPTextSize = Config.Bind("6 - Enemy HUD", nameof(enemyHPTextSize), 10, "Font size of the HP text on the enemy health bar.");
+            enemyNameTextSize = Config.Bind(sectionName, nameof(enemyNameTextSize), 14, "Font size of the name on the enemy.");
 
-            showPlayerHPText = Config.Bind("6 - Enemy HUD", nameof(showPlayerHPText), true, "Show the health numbers on other player's health bar in Multiplayer.");
+            enemyHPTextSize = Config.Bind(sectionName, nameof(enemyHPTextSize), 10, "Font size of the HP text on the enemy health bar.");
 
-            showLocalPlayerEnemyHud = Config.Bind("6 - Enemy HUD", nameof(showLocalPlayerEnemyHud), false, "Show the EnemyHud/HealthBar for your player.");
+            showPlayerHPText = Config.Bind(sectionName, nameof(showPlayerHPText), true, "Show the health numbers on other player's health bar in Multiplayer.");
+
+            showLocalPlayerEnemyHud = Config.Bind(sectionName, nameof(showLocalPlayerEnemyHud), false, "Show the EnemyHud/HealthBar for your player.");
             showLocalPlayerEnemyHud.SettingChanged += (_, _) => BetterEnemyHud.ShowLocalPlayerEnemyHudConfigChanged();
 
-            playerHPTextSize = Config.Bind("6 - Enemy HUD", nameof(playerHPTextSize), 10, "The size of the font to display on other player's health bar in Multiplayer.");
+            playerHPTextSize = Config.Bind(sectionName, nameof(playerHPTextSize), 10, "The size of the font to display on other player's health bar in Multiplayer.");
 
-            bossHPTextSize = Config.Bind("6 - Enemy HUD", nameof(bossHPTextSize), 14, "The size of the font To display on the Boss's health bar.");
+            bossHPTextSize = Config.Bind(sectionName, nameof(bossHPTextSize), 14, "The size of the font to display on the Boss's health bar.");
 
-            makeTamedHPGreen = Config.Bind("6 - Enemy HUD", nameof(makeTamedHPGreen), true, "Make the health bar for tamed creatures green instead of red.");
+            makeTamedHPGreen = Config.Bind(sectionName, nameof(makeTamedHPGreen), true, "Make the health bar for tamed creatures green instead of red.");
 
-            maxShowDistance = Config.Bind("6 - Enemy HUD", nameof(maxShowDistance), 1f, "How far you will see enemy HP Bar. This is an multiplier, 1 = game default. 2 = 2x default");
+            maxShowDistance = Config.Bind(sectionName, nameof(maxShowDistance), 1f, "How far you will see enemy HP Bar. This is an multiplier, 1 = game default, 2 = 2x default.");
 
 
             // Map
-            mapPinScaleSize = Config.Bind("7 - Map", nameof(mapPinScaleSize), 1f, "Scale map pins by this factor. Ex. 1.5 makes the 150% of original size.");
+            sectionName = "7 - Map";
+
+            mapPinScaleSize = Config.Bind(sectionName, nameof(mapPinScaleSize), 1f, "Scale map pins by this factor. Ex. 1.5 makes the 150% of original size.");
+
 
             // Debug
-            isDebug = Config.Bind("8 - Debug", nameof(isDebug), false, "Enable debug logging");
+            sectionName = "8 - Debug";
 
-            /* =======================
-             *         xDataUI
-             * =======================
-             */
-            uiData = Config.Bind("9 - xDataUI", nameof(uiData), "none", "This is your customized UI info. (Edit to none, if having issues with UI)");
-            /*
-            showXPNotifications = Config.Bind("UI", "ShowXPNotifications", true, "Show when you gain xp from actions.");
-            extendedXPNotification = Config.Bind("UI", "extendedXPNotification", true, "Extend notification with: (xp gained) [current/overall xp]");
-            notificationTextSize = Config.Bind("UI", "notificationTextSize", 14, "Edit XP notification font size.");
-            customSkillUI = Config.Bind("UI", "useCustomSkillUI", true, "Toggle the use of custom skills UI");
-            skillUITextSize = Config.Bind("UI", "skillUITextSize", 14, "Select text size on skills UI");
-            showCustomCharInfo = Config.Bind("UI", "showCustomCharInfo", true, "Toggle the visibility of custom info on character selection");
-            showCombinedItemStats = Config.Bind("UI", "showCombinedItemStats", true, "Show all item stats when mouse is hovered over armour amount.");
-            timeLeftStyleFermenter = Config.Bind("UI", "timeLeftStyleFermenter", 2, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left");
-            timeLeftStylePlant = Config.Bind("UI", "timeLeftStylePlant", 2, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left");
-            timeLeftStyleCookingStation = Config.Bind("UI", "timeLeftStyleCookingStation", 2, "Select duration display. 0 = Default, 1= % Done, 2 = min:sec left");
-            chestHasRoomStyle = Config.Bind("UI", "chestHasRoomStyle", 2, "Select how chest emptyness is displayed. 0 = Default | 1 = % | 2 = items / max_room. | 3 = free slots ");
+            isDebug = Config.Bind(sectionName, nameof(isDebug), false, "Enable debug logging.");
 
-            showDurabilityColor = Config.Bind("Item", "ShowDurabilityColor", true, "Show colored durability bars");
-            showItemStars = Config.Bind("Item", "showItemStars", true, "Show item quality as stars");
-            showCustomTooltips = Config.Bind("Item", "showCustomTooltips", true, "Show customized tooltips.");
-            iconScaleSize = Config.Bind("Item", "ScaleSize", 0.75f, "Scale item icon by this factor. Ex. 0.75 makes them 75% of original size");
 
-            customEnemyHud = Config.Bind("HUD", "useCustomEnemyHud", true, "Toggle the use of custom enemy hud");
-            hideEnemyHPText = Config.Bind("HUD", "hideEnemyHPText", false, "Toggle if you want to hide the text with HP amount");
-            enemyLvlStyle = Config.Bind("HUD", "enemyLvlStyle", 1, "Choose how enemy lvl is shown. 0 = Default(stars) | 1 = Prefix before name (Lv. 1) | 2 = Both");
-            enemyHudTextSize = Config.Bind("HUD", "enemyHudTextSize", 14, "Select Text size on enemyHud");
-            maxShowDistance = Config.Bind("HUD", "MaxShowDistance", 1f, "How far you will see enemy HP Bar. This is an multiplier, 1 = game default. 2 = 2x default");
-            mapPinScaleSize = Config.Bind("HUD", "mapPinSize", 1f, "Scale map pins by this factor. Ex. 1.5 makes the 150% of original size.");
-            */
+            // xDataUI
+            sectionName = "9 - xDataUI";
+            uiData = Config.Bind(sectionName, nameof(uiData), "none", "This is your customized UI info. Edit to none, if having issues or wanting to reset positions.");
         }
         public void Start()
         {
             harmony.PatchAll(assembly);
         }
+
         /*
         public void OnDestroy()
         {

--- a/BetterUI/Main.cs
+++ b/BetterUI/Main.cs
@@ -138,7 +138,7 @@ namespace BetterUI
 
             customSpoilerBarRotation = Config.Bind(sectionName, nameof(customSpoilerBarRotation), 90, "Rotate bar for the new spoiler resource in degrees.");
 
-            customFoodBarRotation = Config.Bind(sectionName, nameof(customFoodBarRotation), 90, "Rotate foodbar in degrees.");
+            customFoodBarRotation = Config.Bind(sectionName, nameof(customFoodBarRotation), 180, "Rotate foodbar in degrees.");
 
 
             // Character Inventory

--- a/BetterUI/Patches/CustomElements.cs
+++ b/BetterUI/Patches/CustomElements.cs
@@ -5,224 +5,358 @@ using UnityEngine.UI;
 
 namespace BetterUI.Patches
 {
-  static class CustomElements
-  {
-    public static class HealthBar
+    internal class CustomElements
     {
-      public static readonly string objectName = "BetterUI_HPBar";
-      private static RectTransform healthBarRoot;
-      private static GuiBar healthBarSlow;
-      private static GuiBar healthBarFast;
-      private static Text healthText;
-
-      public static void Create()
-      {
-        try
+        public static class BarHelper
         {
-          // Hide original healthBar
-          Hud.instance.transform.Find("hudroot").Find("healthpanel").gameObject.SetActive(false);
+            public static float StepSize => Hud.instance.m_healthPanel.sizeDelta.x;
 
-          healthBarRoot = UnityEngine.Object.Instantiate(Hud.instance.m_healthBarRoot, Hud.instance.transform.Find("hudroot"));
-          healthBarRoot.gameObject.name = objectName;
+            public const float scalingFactor = 0.6f;
+            public const int padding = 0;
 
-          // Rotate this to 90
-          int rot = 90 - (Main.healthBarRotation.Value / 90 % 4 * 90);
-          healthBarRoot.localEulerAngles = new Vector3(0, 0, rot);
-
-          healthBarFast = healthBarRoot.Find("fast").GetComponent<GuiBar>();
-          healthBarSlow = healthBarRoot.Find("slow").GetComponent<GuiBar>();
-
-          healthBarRoot.Find("fast").Find("bar").Find("HealthText").gameObject.SetActive(false);
-
-          healthText = UnityEngine.Object.Instantiate(healthBarRoot.Find("fast").Find("bar").Find("HealthText").GetComponent<Text>(), healthBarRoot);
-          healthText.GetComponent<RectTransform>().localEulerAngles = new Vector3(0, 0, -rot);
-          healthText.GetComponent<RectTransform>().localScale = new Vector3(0.65f, 0.65f, 1f);
-          healthText.gameObject.SetActive(true);
-
-          // Resize to a more "slim" rectangle - authors preference
-          healthBarRoot.Find("border").GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-          healthBarRoot.Find("bkg").GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-          healthBarFast.GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-          healthBarSlow.GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-
-        }
-        catch (Exception e)
-        {
-          Debug.LogError($"HealthBar.Create() {e.Message}");
-        }
-      }
-
-      public static void Update(float max, float hp)
-      {
-        try
-        {
-          healthBarFast.SetMaxValue(max);
-          healthBarFast.SetValue(hp);
-          healthBarSlow.SetMaxValue(max);
-          healthBarSlow.SetValue(hp);
-          healthText.text = $"{Mathf.CeilToInt(hp)}/{Mathf.CeilToInt(max)}";
-        }
-        catch (Exception e)
-        {
-          Debug.LogError($"HealthBar.Update() {e.Message}");
-        }
-      }
-    }
-
-    public static class StaminaBar
-    {
-      public static readonly string objectName = "BetterUI_StaminaBar";
-      private static RectTransform staminaBarRoot;
-      private static GuiBar staminaBarSlow;
-      private static GuiBar staminaBarFast;
-      private static Text staminaText;
-
-      public static void Create()
-      {
-        try
-        {
-          // Hide original staminaBar
-          Hud.instance.transform.Find("hudroot").Find("staminapanel").gameObject.SetActive(false);
-
-          staminaBarRoot = UnityEngine.Object.Instantiate(Hud.instance.m_healthBarRoot, Hud.instance.transform.Find("hudroot"));
-          staminaBarRoot.gameObject.name = objectName;
-
-          int rot = 90 - (Main.staminaBarRotation.Value / 90 % 4 * 90);
-          staminaBarRoot.localEulerAngles = new Vector3(0, 0, rot);
-
-          staminaBarFast = staminaBarRoot.Find("fast").GetComponent<GuiBar>();
-          staminaBarSlow = staminaBarRoot.Find("slow").GetComponent<GuiBar>();
-
-          staminaBarRoot.Find("fast").Find("bar").Find("HealthText").gameObject.SetActive(false);
-
-          staminaText = UnityEngine.Object.Instantiate(staminaBarRoot.Find("fast").Find("bar").Find("HealthText").GetComponent<Text>(), staminaBarRoot);
-          staminaText.GetComponent<RectTransform>().localEulerAngles = new Vector3(0, 0, -rot);
-          staminaText.GetComponent<RectTransform>().localScale = new Vector3(0.65f, 0.65f, 1f);
-          staminaText.gameObject.SetActive(true);
-
-          staminaBarRoot.Find("border").GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-          staminaBarRoot.Find("bkg").GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-          staminaBarFast.GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-          staminaBarSlow.GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-
-          staminaBarFast.m_originalColor = Hud.instance.m_staminaBar2Fast.m_bar.GetComponent<Image>().color;
-          staminaBarFast.ResetColor();
-          staminaBarSlow.m_originalColor = Hud.instance.m_staminaBar2Slow.m_bar.GetComponent<Image>().color;
-          staminaBarSlow.ResetColor();
-
-          staminaBarFast.m_smoothDrain = Hud.instance.m_staminaBar2Fast.m_smoothDrain;
-          staminaBarFast.m_changeDelay = Hud.instance.m_staminaBar2Fast.m_changeDelay;
-          staminaBarFast.m_smoothSpeed = Hud.instance.m_staminaBar2Fast.m_smoothSpeed;
-        }
-        catch (Exception e)
-        {
-          Debug.LogError($"StaminaBar.Create() {e.Message}");
-        }
-      }
-
-      public static void Update(float max, float stamina)
-      {
-        try
-        {
-          staminaBarFast.SetValue(stamina / max);
-          staminaBarSlow.SetValue(stamina / max);
-          staminaText.text = $"{Mathf.CeilToInt(stamina)}/{Mathf.CeilToInt(max)}";
-        }
-        catch (Exception e)
-        {
-          Debug.LogError($"StaminaBar.Update() {e.Message}");
-        }
-      }
-    }
-
-    public static class FoodBar
-    {
-      public static readonly string objectName = "BetterUI_FoodBar";
-      private static RectTransform foodPanel;
-      private static RectTransform foodBarRoot;
-      public static RectTransform food0;
-      public static RectTransform food1;
-      public static RectTransform food2;
-
-      public static void Create()
-      {
-        foodPanel = UnityEngine.Object.Instantiate(Hud.instance.m_healthPanel, Hud.instance.transform.Find("hudroot"));
-        foodPanel.gameObject.name = objectName;
-        foodPanel.gameObject.SetActive(true);
-        int rot = 90 - (Main.foodBarRotation.Value / 90 % 4 * 90);
-        foodPanel.localEulerAngles = new Vector3(0, 0, rot);
-
-        foodBarRoot = foodPanel.Find("Food").GetComponent<RectTransform>();
-        food0 = foodPanel.Find("food0").GetComponent<RectTransform>();
-        food1 = foodPanel.Find("food1").GetComponent<RectTransform>();
-        food2 = foodPanel.Find("food2").GetComponent<RectTransform>();
-
-        food0.localEulerAngles = new Vector3(0, 0, -rot);
-        food1.localEulerAngles = new Vector3(0, 0, -rot);
-        food2.localEulerAngles = new Vector3(0, 0, -rot);
-
-        // Stuff to remove / hide
-        foodPanel.Find("Health").gameObject.SetActive(false);
-        foodPanel.Find("darken").gameObject.SetActive(false);
-        foodPanel.Find("healthicon").gameObject.SetActive(false);
-        foodPanel.Find("foodicon").gameObject.SetActive(false);
-      }
-
-      public static void Update(Player player)
-      {
-        List<Player.Food> foods = player.GetFoods();
-        float baseHP = player.GetBaseFoodHP() / 25f * 32f;
-        foodBarRoot.Find("baseBar").GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, baseHP);
-        float barLength = baseHP;
-        for (int i = 0; i < Hud.instance.m_foodBars.Length; i++)
-        {
-          Image image = Hud.instance.m_foodBars[i]; // foodBarRoot (bar1, bar2, bar3, baseBar?)
-          Image icon = Hud.instance.m_foodIcons[i]; // food0 -> foodicon0
-
-          if (i < foods.Count)
-          {
-            Player.Food food = foods[i];
-            Image tmpImage = foodBarRoot.Find(image.name).GetComponent<Image>();
-            Image tmpIcon = foodPanel.Find($"food{i}").Find($"foodicon{i}").GetComponent<Image>();
-            Text tmpText = foodPanel.Find($"food{i}").Find($"time").GetComponent<Text>();
-            tmpImage.gameObject.SetActive(true);
-            tmpImage.color = image.color;
-            tmpImage.rectTransform.anchoredPosition = image.rectTransform.anchoredPosition;
-            tmpImage.rectTransform.sizeDelta = image.rectTransform.sizeDelta;
-            float barWidth = food.m_health / 25f * 32f;
-            tmpImage.rectTransform.anchoredPosition = new Vector2(barLength, 0f);
-            tmpImage.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, Mathf.Ceil(barWidth));
-            barLength += barWidth;
-
-            tmpIcon.sprite = icon.sprite;
-            tmpIcon.gameObject.SetActive(true);
-            tmpIcon.color = icon.color;
-
-            tmpText.gameObject.SetActive(true);
-            if (food.m_time >= 60f)
+            public static void BaseCreate(string objectName, string origBarName, int configRotation, ref RectTransform root, ref GuiBar slowBar, ref GuiBar fastBar, ref Text barText)
             {
-              tmpText.text = Mathf.CeilToInt(food.m_time / 60f) + "m";
-              tmpText.color = Color.white;
+                // we've obviously already done this before if it's not null
+                if (root != null)
+                {
+                    return;
+                }
+
+                // Hide original bar
+                Hud.instance.transform.Find("hudroot").Find(origBarName).gameObject.SetActive(false);
+
+                root = UnityEngine.Object.Instantiate(Hud.instance.m_healthBarRoot, Hud.instance.transform.Find("hudroot"));
+                root.gameObject.name = objectName;
+
+                int rot = 90 - (configRotation / 90 % 4 * 90);
+                root.localEulerAngles = new Vector3(0, 0, rot);
+
+                fastBar = root.Find("fast").GetComponent<GuiBar>();
+                slowBar = root.Find("slow").GetComponent<GuiBar>();
+
+                root.Find("fast").Find("bar").Find("HealthText").gameObject.SetActive(false);
+
+                barText = UnityEngine.Object.Instantiate(root.Find("fast").Find("bar").Find("HealthText").GetComponent<Text>(), root);
+                barText.GetComponent<RectTransform>().localEulerAngles = new Vector3(0, 0, -rot);
+
+                // Resize to a more "slim" rectangle - authors preference
+                barText.GetComponent<RectTransform>().localScale = new Vector3(scalingFactor, scalingFactor, 1f);
+                barText.gameObject.SetActive(true);
+
+                root.Find("border").GetComponent<RectTransform>().localScale = new Vector3(1f, scalingFactor, 1f);
+                root.Find("bkg").GetComponent<RectTransform>().localScale = new Vector3(1f, scalingFactor, 1f);
+
+                fastBar.GetComponent<RectTransform>().localScale = new Vector3(1f, scalingFactor, 1f);
+                slowBar.GetComponent<RectTransform>().localScale = new Vector3(1f, scalingFactor, 1f);
             }
-            else
+
+            public static void HealthStyleUpdate(float max, float current, ref GuiBar slowBar, ref GuiBar fastBar, ref Text barText)
             {
-              tmpText.text = Mathf.FloorToInt(food.m_time) + "s";
-              tmpText.color = new Color(1f, 1f, 1f, 0.4f + Mathf.Sin(Time.time * 10f) * 0.6f);
+                fastBar.SetMaxValue(max);
+                fastBar.SetValue(current);
+                slowBar.SetMaxValue(max);
+                slowBar.SetValue(current);
+
+                barText.text = $"{Mathf.CeilToInt(current)}/{Mathf.CeilToInt(max)}";
             }
-          }
-          else
-          {
-            Image tmpImage = foodBarRoot.Find(image.name).GetComponent<Image>();
-            Image tmpIcon = foodPanel.Find($"food{i}").Find($"foodicon{i}").GetComponent<Image>();
-            Text tmpText = foodPanel.Find($"food{i}").Find($"time").GetComponent<Text>();
-            tmpImage.gameObject.SetActive(false);
-            tmpIcon.gameObject.SetActive(false);
-            tmpText.gameObject.SetActive(false);
-          }
+
+            public static void StaminaStyleUpdate(float max, float current, ref GuiBar slowBar, ref GuiBar fastBar, ref Text barText)
+            {
+                fastBar.SetValue(current / max);
+                slowBar.SetValue(current / max);
+
+                barText.text = $"{Mathf.CeilToInt(current)}/{Mathf.CeilToInt(max)}";
+            }
         }
-        float size = Mathf.Ceil(player.GetMaxHealth() / 25f * 32f);
-        foodBarRoot.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, size);
-      }
+
+        public static class HealthBar
+        {
+            public static readonly string objectName = "BetterUI_HPBar";
+            internal static RectTransform root;
+            internal static GuiBar slowBar;
+            internal static GuiBar fastBar;
+            internal static Text barText;
+
+            public static void Create()
+            {
+                try
+                {
+                    BarHelper.BaseCreate(objectName, "healthpanel", Main.customHealthBarRotation.Value, ref root, ref slowBar, ref fastBar, ref barText);
+
+                    // go to a good default position that can get overriden by the editing feature if needed
+                    // go up and left
+                    root.position += new Vector3(-BarHelper.StepSize / 4, BarHelper.StepSize / 4);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(HealthBar)}.{nameof(Create)}() {e.Message}");
+                }
+            }
+
+            public static void Update(float max, float current)
+            {
+                try
+                {
+                    if (root != null)
+                    {
+                        BarHelper.HealthStyleUpdate(max, current, ref slowBar, ref fastBar, ref barText);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(HealthBar)}.{nameof(Update)}() {e.Message}");
+                }
+            }
+        }
+
+        public static class StaminaBar
+        {
+            public static readonly string objectName = "BetterUI_StaminaBar";
+            internal static RectTransform root;
+            internal static GuiBar slowBar;
+            internal static GuiBar fastBar;
+            internal static Text barText;
+
+            public static void Create()
+            {
+                try
+                {
+                    BarHelper.BaseCreate(objectName, "staminapanel", Main.customStaminaBarRotation.Value, ref root, ref slowBar, ref fastBar, ref barText);
+
+                    fastBar.m_originalColor = Hud.instance.m_staminaBar2Fast.m_bar.GetComponent<Image>().color;
+                    slowBar.m_originalColor = Hud.instance.m_staminaBar2Slow.m_bar.GetComponent<Image>().color;
+                    fastBar.ResetColor();
+                    slowBar.ResetColor();
+
+                    fastBar.m_smoothDrain = Hud.instance.m_staminaBar2Fast.m_smoothDrain;
+                    fastBar.m_changeDelay = Hud.instance.m_staminaBar2Fast.m_changeDelay;
+                    fastBar.m_smoothSpeed = Hud.instance.m_staminaBar2Fast.m_smoothSpeed;
+
+                    // go to a good default position that can get overriden by the editing feature if needed
+                    // go left
+                    root.position -= new Vector3(BarHelper.StepSize / 4, 0);
+
+                    if (Main.useCustomHealthBar.Value)
+                    {
+                        // hold positon
+                        root.position -= new Vector3(0, BarHelper.padding);
+                    }
+                    else
+                    {
+                        // go up
+                        root.position += new Vector3(0, BarHelper.StepSize / 4);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(StaminaBar)}.{nameof(Create)}() {e.Message}");
+                }
+            }
+
+            public static void Update(float max, float current)
+            {
+                try
+                {
+                    if (root != null)
+                    {
+                        BarHelper.StaminaStyleUpdate(max, current, ref slowBar, ref fastBar, ref barText);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(StaminaBar)}.{nameof(Update)}() {e.Message}");
+                }
+            }
+        }
+
+        public static class EitrBar
+        {
+            public static readonly string objectName = "BetterUI_EitrBar";
+            internal static RectTransform root;
+            internal static GuiBar slowBar;
+            internal static GuiBar fastBar;
+            internal static Text barText;
+
+            public static void Create()
+            {
+                try
+                {
+                    BarHelper.BaseCreate("BetterUI_EitrBar", "eitrpanel", Main.customSpoilerBarRotation.Value, ref root, ref slowBar, ref fastBar, ref barText);
+
+                    fastBar.m_originalColor = Hud.instance.m_eitrBarFast.m_bar.GetComponent<Image>().color;
+                    slowBar.m_originalColor = Hud.instance.m_eitrBarSlow.m_bar.GetComponent<Image>().color;
+                    fastBar.ResetColor();
+                    slowBar.ResetColor();
+
+                    fastBar.m_smoothDrain = Hud.instance.m_eitrBarFast.m_smoothDrain;
+                    fastBar.m_changeDelay = Hud.instance.m_eitrBarFast.m_changeDelay;
+                    fastBar.m_smoothSpeed = Hud.instance.m_eitrBarFast.m_smoothSpeed;
+
+                    // go to a good default position that can get overriden by the editing feature if needed
+                    // go left
+                    root.position -= new Vector3(BarHelper.StepSize / 4, 0);
+
+                    if (Main.useCustomHealthBar.Value)
+                    {
+                        // hold position
+                        root.position -= new Vector3(0, BarHelper.padding);
+
+                        if (Main.useCustomStaminaBar.Value)
+                        {
+                            // go down
+                            root.position -= new Vector3(0, BarHelper.StepSize / 4 + BarHelper.padding);
+                        }
+                    }
+                    else
+                    {
+                        // go up
+                        root.position += new Vector3(0, BarHelper.StepSize / 4);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(EitrBar)}.{nameof(Create)}() {e.Message}");
+                }
+            }
+
+            public static void Update(float max, float current)
+            {
+                try
+                {
+                    if (root != null)
+                    {
+                        BarHelper.StaminaStyleUpdate(max, current, ref slowBar, ref fastBar, ref barText);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(EitrBar)}.{nameof(Update)}() {e.Message}");
+                }
+            }
+        }
+
+        public static class FoodBar
+        {
+            public static readonly string objectName = "BetterUI_FoodBar";
+            private static RectTransform foodPanel;
+            private static RectTransform foodBarRoot;
+            public static RectTransform food0;
+            public static RectTransform food1;
+            public static RectTransform food2;
+
+            public static void Create()
+            {
+                try
+                {
+                    // we've obviously already done this before if it's not null
+                    if (foodPanel != null)
+                    {
+                        return;
+                    }
+
+                    // original food panel gets hidden by hiding the original health bar, so if the user doesn't use that feature, then they would have two food bars
+                    if (!Main.useCustomHealthBar.Value)
+                    {
+                        Debug.LogWarning($"{nameof(Main.useCustomFoodBar)} requires {nameof(Main.useCustomHealthBar)}. No custom food bar will be created. Activate {nameof(Main.useCustomHealthBar)} and log out and back in to use {nameof(Main.useCustomFoodBar)}.");
+                        return;
+                    }
+
+                    foodPanel = UnityEngine.Object.Instantiate(Hud.instance.m_healthPanel, Hud.instance.transform.Find("hudroot"));
+                    foodPanel.gameObject.name = objectName;
+                    foodPanel.gameObject.SetActive(true);
+                    int rot = 90 - (Main.customFoodBarRotation.Value / 90 % 4 * 90);
+                    foodPanel.localEulerAngles = new Vector3(0, 0, rot);
+
+                    foodBarRoot = foodPanel.Find("Food").GetComponent<RectTransform>();
+                    food0 = foodPanel.Find("food0").GetComponent<RectTransform>();
+                    food1 = foodPanel.Find("food1").GetComponent<RectTransform>();
+                    food2 = foodPanel.Find("food2").GetComponent<RectTransform>();
+
+                    food0.localEulerAngles = new Vector3(0, 0, -rot);
+                    food1.localEulerAngles = new Vector3(0, 0, -rot);
+                    food2.localEulerAngles = new Vector3(0, 0, -rot);
+
+                    // Stuff to remove / hide
+                    foodPanel.Find("Health").gameObject.SetActive(false);
+                    foodPanel.Find("darken").gameObject.SetActive(false);
+                    foodPanel.Find("healthicon").gameObject.SetActive(false);
+
+                    // hide the fork icon. mistlands renamed this one, probably from editor dropping a new version into the scene (might also explain why the armor icon had a fork icon)
+                    foodPanel.Find("foodicon (1)").gameObject.SetActive(false);
+
+                    foodPanel.position = Hud.instance.m_gpRoot.position;
+                    foodPanel.position += new Vector3(-foodPanel.sizeDelta.x / 4, foodPanel.sizeDelta.x / 2);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(FoodBar)}.{nameof(Create)}() {e.Message}");
+                }
+            }
+
+            // based on HUD.UpdateFood()
+            public static void Update(Player player)
+            {
+                try
+                {
+                    if (foodPanel != null)
+                    {
+                        List<Player.Food> foods = player.GetFoods();
+                        float baseHP = player.GetBaseFoodHP() / 25f * 32f;
+                        foodBarRoot.Find("baseBar").GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, baseHP);
+                        float barLength = baseHP;
+
+                        for (int i = 0; i < Hud.instance.m_foodBars.Length; i++)
+                        {
+                            Image image = foodBarRoot.Find(Hud.instance.m_foodBars[i].name).GetComponent<Image>();
+                            Image image2 = foodPanel.Find($"food{i}").Find($"foodicon{i}").GetComponent<Image>();
+                            Text text = foodPanel.Find($"food{i}").Find($"time").GetComponent<Text>();
+
+                            if (i < foods.Count)
+                            {
+                                image.gameObject.SetActive(true);
+                                Player.Food food = foods[i];
+                                image2.gameObject.SetActive(true);
+                                image2.sprite = food.m_item.GetIcon();
+
+                                if (food.CanEatAgain())
+                                {
+                                    image2.color = new Color(1f, 1f, 1f, 0.7f + Mathf.Sin(Time.time * 5f) * 0.3f);
+                                }
+                                else
+                                {
+                                    image2.color = Color.white;
+                                }
+
+                                text.gameObject.SetActive(true);
+
+                                if (food.m_time >= 60f)
+                                {
+                                    text.text = Mathf.CeilToInt(food.m_time / 60f) + "m";
+                                    text.color = Color.white;
+                                }
+                                else
+                                {
+                                    text.text = Mathf.FloorToInt(food.m_time) + "s";
+                                    text.color = new Color(1f, 1f, 1f, 0.4f + Mathf.Sin(Time.time * 10f) * 0.6f);
+                                }
+                            }
+                            else
+                            {
+                                image.gameObject.SetActive(false);
+                                image2.gameObject.SetActive(false);
+                                text.gameObject.SetActive(false);
+                            }
+                        }
+
+                        float size = Mathf.Ceil(player.GetMaxHealth() / 25f * 32f);
+                        foodBarRoot.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, size);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(FoodBar)}.{nameof(Update)}() {e.Message}");
+                }
+            }
+        }
     }
-  }
 }

--- a/BetterUI/Patches/CustomHud.cs
+++ b/BetterUI/Patches/CustomHud.cs
@@ -37,6 +37,7 @@ namespace BetterUI.Patches
       new Element(CustomElements.HealthBar.objectName, Groups.HudRoot, CustomElements.HealthBar.objectName, "HP Bar"),
       new Element(CustomElements.FoodBar.objectName, Groups.HudRoot, CustomElements.FoodBar.objectName, "Food Bar"),
       new Element(CustomElements.StaminaBar.objectName, Groups.HudRoot, CustomElements.StaminaBar.objectName, "Stamina Bar"),
+      new Element(CustomElements.EitrBar.objectName, Groups.HudRoot, CustomElements.EitrBar.objectName, "Eitr Bar"),
       new Element("QuickSlots", Groups.HudRoot, "QuickSlotsHotkeyBar", "QuickSlots")
       //new Element("QuickSlotsHotkeyBar", Groups.HudRoot, "healthpanel/Health/QuickSlotsHotkeyBar", "QuickSlotsHotkey"),
       //new Element("QuickSlotGrid", Groups.Inventory, "Player/QuickSlotGrid", "QuickSlots"),

--- a/BetterUI/Patches/RPG.cs
+++ b/BetterUI/Patches/RPG.cs
@@ -13,8 +13,22 @@ namespace BetterUI.Patches
         private static Color barColor = Color.yellow;
         private static GuiBar _xp_bar = null;
 
-        public static GuiBar Awake(Hud __instance)
+        public static void UpdateLevelProgressPercentage()
         {
+            if(_xp_bar != null)
+            {
+                _xp_bar.SetValue(XP.LevelProgressPercentage);
+            }
+        }
+
+        public static void Create(Hud __instance)
+        {
+            // we've obviously already done this before if it's not null
+            if (_xp_bar != null)
+            {
+                return;
+            }
+
             Transform hudroot = Utils.FindChild(__instance.gameObject.transform, "hudroot");
             GuiBar xp_bar = UnityEngine.Object.Instantiate(Hud.instance.m_stealthBar, hudroot, true);
             xp_bar.m_barImage = Hud.instance.m_stealthBar.m_bar.GetComponent<Image>();
@@ -48,16 +62,20 @@ namespace BetterUI.Patches
             // Render the XP Bar 
             xp_bar.gameObject.SetActive(true);
             _xp_bar = xp_bar;
-
-            return xp_bar;
         }
 
         public static void UpdatePosition()
         {
-            if (_xp_bar == null) return;
-            RectTransform xpRect = (_xp_bar.transform as RectTransform);
-            if (xpRect == null) return;
-            _xp_bar.m_bar.sizeDelta = xpRect.rect.size;
+            if (_xp_bar != null)
+            {
+                // maybe use 'is' syntax, but may not reliable be for unity components (just like ?. doesn't work on monobehaviours)
+                var xpRect = _xp_bar.transform as RectTransform;
+
+                if(xpRect != null)
+                {
+                    _xp_bar.m_bar.sizeDelta = xpRect.rect.size;
+                }
+            }
         }
     }
 
@@ -79,6 +97,7 @@ namespace BetterUI.Patches
                 Debug.LogWarning("Didn't get a player");
                 return;
             }
+
             RPG_Player = player;
 
             UpdatePlayerXP();


### PR DESCRIPTION
Fixes #31

Issues that I want to address with this PR:
- user enable/ disable the health, stamina, food and xp bar ingame, this either leads to potential null reference exceptions either from the mod talking to a bar that doesn't exist or turns an existing bar non functional without reenabling the default one
- users are constantly confused that they need to restart (or how to restart) after enabling / disabling a bar, because the config description is too hidden
- the mod doesn't support resource bar for the new mistlands resource Eitr yet (I'm avoiding spoilers here since I know you haven't played yet)
- unbeknownst to the user, the new bar config options only do something when 'enablePlayerHudEditing' is also enabled
- the default display of the custom bars is not satisfying because their positions heavily overlap due to being the default instantiated positions
- users may be confused about the name of the rotation config options not specifying that they only affect the custom bars
- enabling the custom food bar while having the custom health bar disabled would lead to two food bars since we disable the entire health and food bar object when enabling the custom health bar

This PR addresses these issues in the following ways:
- after spawning or not spawning the bars in HUD.Awake based on the config, the mod completely ignores the config values and also never talks to the bar objects directly until the user logs out. That means that the bar classes have complete control over the bars after they were spawned and get to continue to function until they are destroyed by a logout

- the config file has been edited: the bar settings now have their own section that explicitely mentions that you need to logout (full restarts also work of course, but the mod only requires HUD.Awake for a full reset). this change will reset the affected config options (and only those) for ALL users, since the config options are stored as a pair of section and name. this is okay, because hitting boolean toggles is not a lot of work and most users are probably not using the custom bars in the first place. the customized positions of bars are saved in '"9 - xDataUI","uiData"' and are therefore not affected. we use this reset opportunity to also rename the rotation config options to avoid potential confusion

- the CustomElements class has been heavily modified. the three bar types shared a lot of copy pasted code. this has been refactored into a helper class which increases future maintainability. inheritance was not an option due to the heavy use of the static modifier in the existing implementation

- the fork icon next to the custom food bar has been removed again. The issue was caused by its name changing from "foodicon" to "foodicon (1)" in a recent update (probably when they removed the food bars)
- the custom food bar now does not spawn when the custom health bar is disabled and a warning is printed into the log to inform the user. additionally the descriptions of the custom health and food bar were updated to tell the user about this dependency. hopefully not spawning the bar instead of spawning two bars gets the user to notice their mistake more easily
- the Update method of the FoodBar has been updated to reflect HUD.UpdateFood again. Food icons are now blinking again when they can be refreshed

- the newly created framework has been used to add support for the resource bar of the new mistlands resource Eitr. as I have not used Eitr much I don't know if this new bar may miss out on some special visual effects (it is once again a clone of the health bar after all), but it's fully functional including when the maximum of the resource gets reset to zero
- the new bars have satisfying default positions (see the attached image), including when not all of them are enabled, and no longer require 'enablePlayerHudEditing' to be enabled to function. the default positions don't affect users with already edited positions because those are loaded afterwards and override these default positions

![PRfood](https://user-images.githubusercontent.com/22944589/207383263-82767b6e-16ed-47c9-8f3d-1c6c18a03acd.png)