### PR TITLE
Future Release: scaling, enum config, mini features

### DIFF
--- a/BetterUI/BetterUI.csproj
+++ b/BetterUI/BetterUI.csproj
@@ -329,6 +329,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="GameClasses\BeeHive.cs" />
     <Compile Include="GameClasses\Container.cs" />
     <Compile Include="GameClasses\CookingStation.cs" />
     <Compile Include="GameClasses\EnemyHud.cs" />
@@ -346,14 +347,17 @@
     <Compile Include="GameClasses\Smelter.cs" />
     <Compile Include="Main.cs" />
     <Compile Include="Patches\Compatibility.cs" />
-    <Compile Include="Patches\CustomElements.cs" />
+    <Compile Include="Patches\CustomBars.cs" />
     <Compile Include="Patches\CustomHud.cs" />
     <Compile Include="Patches\Helpers.cs" />
     <Compile Include="Patches\HoverText.cs" />
+    <Compile Include="Patches\HudElement.cs" />
     <Compile Include="Patches\Items.cs" />
     <Compile Include="Patches\Menu.cs" />
+    <Compile Include="Patches\ItemIconUpdater.cs" />
     <Compile Include="Patches\RPG.cs" />
     <Compile Include="Patches\Skill.cs" />
+    <Compile Include="Patches\TextScaler.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Content Include="Package\icon.png" />
     <None Include="GameDir.targets" />

--- a/BetterUI/GameClasses/BeeHive.cs
+++ b/BetterUI/GameClasses/BeeHive.cs
@@ -1,0 +1,28 @@
+﻿using HarmonyLib;
+using System.Configuration;
+
+namespace BetterUI.GameClasses
+{
+    [HarmonyPatch]
+    internal class BetterBeeHive
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(Beehive), "GetHoverText")]
+        private static bool GetHoverText(Beehive __instance, ref string __result)
+        {
+            if (Main.timeLeftHoverTextBeeHive.Value == 0)
+            {
+                return true;
+            }
+
+            if (!PrivateArea.CheckAccess(__instance.transform.position, 0f, false, false))
+            {
+                __result = Localization.instance.Localize(__instance.m_name + "\n$piece_noaccess");
+                return false;
+            }
+
+            Patches.HoverText.PatchBeeHive(__instance, ref __result);
+            return false;
+        }
+    }
+}

--- a/BetterUI/GameClasses/Container.cs
+++ b/BetterUI/GameClasses/Container.cs
@@ -9,7 +9,7 @@ namespace BetterUI.GameClasses
     [HarmonyPatch(typeof(Container), "GetHoverText")]
     private static void GetHoverText(Container __instance, ref string __result)
     {
-      if (Main.chestHasRoomStyle.Value == 0) return;
+      if (Main.chestHasRoomHoverText.Value == 0) return;
 
       if (__instance.m_inventory.NrOfItems() != 0)
       {

--- a/BetterUI/GameClasses/CookingStation.cs
+++ b/BetterUI/GameClasses/CookingStation.cs
@@ -10,7 +10,7 @@ namespace BetterUI.GameClasses
     [HarmonyPatch(typeof(CookingStation), "GetHoverText")]
     private static bool GetHoverText(CookingStation __instance, ref string __result)
     {
-      if (Main.timeLeftStyleCookingStation.Value == 0) return true;
+      if (Main.timeLeftHoverTextCookingStation.Value == 0) return true;
 
       return Patches.HoverText.PatchCookingStation(__instance, ref __result);
     }

--- a/BetterUI/GameClasses/EnemyHud.cs
+++ b/BetterUI/GameClasses/EnemyHud.cs
@@ -84,7 +84,7 @@ namespace BetterUI.GameClasses
             else
             {
                 hudData.m_name.fontSize = Main.enemyNameTextSize.Value;
-                if (Main.enemyLvlStyle.Value != 0)
+                if (Main.enemyLevelStyle.Value != 0)
                 {
                     hudData.m_name.text = hudData.m_name.text.Insert(0, $"<size={Main.enemyNameTextSize.Value}><color=white>Lv.{c.m_level} </color></size> ");
                 }
@@ -117,7 +117,7 @@ namespace BetterUI.GameClasses
                 hudData.m_healthFast.m_bar.sizeDelta = new Vector2(hudData.m_healthFast.m_width, hpRoot.sizeDelta.y);
                 hudData.m_healthSlow.m_bar.sizeDelta = new Vector2(hudData.m_healthSlow.m_width, hpRoot.sizeDelta.y);
 
-                if (Main.enemyLvlStyle.Value == 1)
+                if (Main.enemyLevelStyle.Value == Main.EnemyLevelStyle.PrefixLevelNumber)
                 {
                     hudData.m_level2.gameObject.SetActive(false);
                     hudData.m_level3.gameObject.SetActive(false);
@@ -175,12 +175,12 @@ namespace BetterUI.GameClasses
                           hpText.text = $"<size={Main.enemyHPTextSize.Value}>{value.m_character.GetHealth():0}/{value.m_character.GetMaxHealth():0}</size>";
                         }
 
-                        if (Main.enemyLvlStyle.Value != 0)
+                        if (Main.enemyLevelStyle.Value != 0)
                         {
                             value.m_name.text = value.m_name.text.Insert(0, $"<size={Main.enemyNameTextSize.Value}><color=white>Lv.{value.m_character.m_level} </color></size> ");
                         }
 
-                        if (Main.enemyLvlStyle.Value == 1)
+                        if (Main.enemyLevelStyle.Value == Main.EnemyLevelStyle.PrefixLevelNumber)
                         {
                             value.m_level2.gameObject.SetActive(false);
                             value.m_level3.gameObject.SetActive(false);

--- a/BetterUI/GameClasses/Fermenter.cs
+++ b/BetterUI/GameClasses/Fermenter.cs
@@ -9,7 +9,7 @@ namespace BetterUI.GameClasses
     [HarmonyPatch(typeof(Fermenter), "GetHoverText")]
     private static bool GetHoverText(Fermenter __instance, ref string __result)
     {
-      if (Main.timeLeftStyleFermenter.Value == 0) return true;
+      if (Main.timeLeftHoverTextFermenter.Value == 0) return true;
 
       if (!PrivateArea.CheckAccess(__instance.transform.position, 0f, false, false))
       {

--- a/BetterUI/GameClasses/HotkeyBar.cs
+++ b/BetterUI/GameClasses/HotkeyBar.cs
@@ -15,9 +15,23 @@ namespace BetterUI.GameClasses
                 return;
             }
 
+            HotkeyBar.ElementData element;
+            float xPos;
+
             foreach (ItemDrop.ItemData itemData in __instance.m_items)
             {
-                HotkeyBar.ElementData element = __instance.m_elements[itemData.m_gridPos.x];
+                element = null;
+                xPos = itemData.m_gridPos.x;
+
+                if (xPos >= 0 && xPos < __instance.m_elements.Count)
+                {
+                    element = __instance.m_elements[itemData.m_gridPos.x];
+                }
+
+                if (element == null)
+                {
+                    return;
+                }
 
                 // would be better if this could be done reliably in an Awake/ Start, but I'm not in the mood to look for one
                 if (element.m_icon.gameObject.GetComponent<ItemIconUpdater>() == null)

--- a/BetterUI/GameClasses/InventoryGrid.cs
+++ b/BetterUI/GameClasses/InventoryGrid.cs
@@ -1,51 +1,37 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using BetterUI.Patches;
 using HarmonyLib;
-using UnityEngine;
 
 namespace BetterUI.GameClasses
 {
-  [HarmonyPatch]
-  public static class BetterInventoryGrid
-  {
-    [HarmonyPostfix]
-    [HarmonyPatch(typeof(InventoryGrid), "UpdateGui")]
-    private static void PatchInventory(ref InventoryGrid __instance, ref Player player, ItemDrop.ItemData dragItem)
+    [HarmonyPatch]
+    public static class BetterInventoryGrid
     {
-      if (!Main.showDurabilityColor.Value && !Main.showItemStars.Value) return;
-
-      foreach (ItemDrop.ItemData itemData in __instance.m_inventory.GetAllItems())
-      {
-        InventoryGrid.Element element = __instance.GetElement(itemData.m_gridPos.x, itemData.m_gridPos.y, __instance.m_inventory.GetWidth());
-        if (element.m_icon.transform.localScale == Vector3.one) element.m_icon.transform.localScale *= Mathf.Max(Main.iconScaleSize.Value, 0.1f);
-        if (itemData.m_shared.m_useDurability)
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(InventoryGrid), "UpdateGui")]
+        private static void PatchInventory(ref InventoryGrid __instance, ref Player player, ItemDrop.ItemData dragItem)
         {
-          if (itemData.m_durability <= 0f) // Item has no durability, original code should do this
-          {
-            //element.m_durability.SetValue(1f);
-            //element.m_durability.SetColor((Mathf.Sin(Time.time * 10f) > 0f) ? Color.red : new Color(0f, 0f, 0f, 0f));
-
-          }
-          else // Item has durability left
-          {
-            if (Main.showDurabilityColor.Value)
+            foreach (ItemDrop.ItemData itemData in __instance.m_inventory.GetAllItems())
             {
-              Patches.DurabilityBar.UpdateColor(element, itemData.GetDurabilityPercentage());
+                InventoryGrid.Element element = __instance.GetElement(itemData.m_gridPos.x, itemData.m_gridPos.y, __instance.m_inventory.GetWidth());
+
+                // would be better if this could be done reliably in an Awake/ Start, but I'm not in the mood to look for one
+                if (element.m_icon.gameObject.GetComponent<ItemIconUpdater>() == null)
+                {
+                    var origScaleComp = element.m_icon.gameObject.AddComponent<ItemIconUpdater>();
+                    origScaleComp.Setup(element.m_icon);
+                }
+
+                ElementHelper.UpdateElement(element.m_durability, element.m_icon, itemData);
+
+                // Change item quality info (HotKeyBar doesn't do this, so we don't add it to UpdateElement)
+                if (Main.showItemStars.Value)
+                {
+                    if (itemData.m_shared.m_maxQuality > 1)
+                    {
+                        Stars.Draw(element, itemData.m_quality);
+                    }
+                }
             }
-          }
         }
-        // Change item quality info
-        if (itemData.m_shared.m_maxQuality > 1)
-        {
-          if (Main.showItemStars.Value)
-          {
-            Patches.Stars.Draw(element, itemData.m_quality);
-          }
-        }
-      }
     }
-  }
 }

--- a/BetterUI/GameClasses/InventoryGrid.cs
+++ b/BetterUI/GameClasses/InventoryGrid.cs
@@ -10,9 +10,24 @@ namespace BetterUI.GameClasses
         [HarmonyPatch(typeof(InventoryGrid), "UpdateGui")]
         private static void PatchInventory(ref InventoryGrid __instance, ref Player player, ItemDrop.ItemData dragItem)
         {
+            var width = __instance.m_inventory.GetWidth();
+            InventoryGrid.Element element;
+            int index;
+
             foreach (ItemDrop.ItemData itemData in __instance.m_inventory.GetAllItems())
             {
-                InventoryGrid.Element element = __instance.GetElement(itemData.m_gridPos.x, itemData.m_gridPos.y, __instance.m_inventory.GetWidth());
+                index = itemData.m_gridPos.y * width + itemData.m_gridPos.x;
+                element = null;
+
+                if (index >= 0 && index < __instance.m_elements.Count)
+                {
+                    element = __instance.m_elements[index];
+                }
+
+                if (element == null)
+                {
+                    return;
+                }
 
                 // would be better if this could be done reliably in an Awake/ Start, but I'm not in the mood to look for one
                 if (element.m_icon.gameObject.GetComponent<ItemIconUpdater>() == null)

--- a/BetterUI/GameClasses/Plant.cs
+++ b/BetterUI/GameClasses/Plant.cs
@@ -9,7 +9,7 @@ namespace BetterUI.GameClasses
     [HarmonyPatch(typeof(Plant), "GetHoverText")]
     private static bool GetHoverText(Plant __instance, ref string __result)
     {
-			if (Main.timeLeftStylePlant.Value == 0) return true;
+			if (Main.timeLeftHoverTextPlant.Value == 0) return true;
 
       return Patches.HoverText.PatchPlant(__instance, ref __result);
     }

--- a/BetterUI/GameClasses/Skills.cs
+++ b/BetterUI/GameClasses/Skills.cs
@@ -25,10 +25,8 @@ namespace BetterUI.GameClasses
             [HarmonyPatch(typeof(Skills.Skill), "Raise")]
             private static void CalculateXP(ref Skills __instance, float factor)
             {
-                //if (BetterHud._bar == null) return;
-
                 Patches.XP.RaiseXP();
-                if (Main.showCharacterXpBar.Value) BetterHud._bar.SetValue(Patches.XP.LevelProgressPercentage);
+                Patches.XPBar.UpdateLevelProgressPercentage();
             }
         }
     }

--- a/BetterUI/Main.cs
+++ b/BetterUI/Main.cs
@@ -38,9 +38,11 @@ namespace BetterUI
         public static ConfigEntry<CustomBarState> customEitrBar;
         public static ConfigEntry<CustomBarState> customFoodBar;
         public static ConfigEntry<int> customBarTextSize;
+        public static ConfigEntry<int> customFoodBarTextSize;
 
         // Player Inventory
         public static ConfigEntry<DurabilityBarStyle> durabilityBarColorPalette;
+
         public static ConfigEntry<bool> showItemStars;
         public static ConfigEntry<bool> showCustomCharInfo;
         public static ConfigEntry<bool> showCustomTooltips;
@@ -123,6 +125,9 @@ namespace BetterUI
             modKeySecondary = Config.Bind(sectionName, nameof(modKeySecondary), KeyCode.LeftControl,
                 "Key needed to be held down to change an elements scale with the mouse wheel, as well as its X and Y dimensions by moving the mouse. Accepted Values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
 
+            customBarTextSize = Config.Bind(sectionName, nameof(customBarTextSize), 15, "Font size of the text on the custom bars.");
+            customFoodBarTextSize = Config.Bind(sectionName, nameof(customFoodBarTextSize), 15, "Font size of the duration text of food items in the custom food bar.");
+
             // Player HUD RESTART
             sectionName = "1 - Player HUD (Requires Logout)";
 
@@ -154,8 +159,6 @@ namespace BetterUI
             customEitrBar = Config.Bind(sectionName, nameof(customEitrBar), eitrDefault ? CustomBarState.on0Degrees : CustomBarState.off, "Resizable, rotatable eitr bar. If you don't know what this is yet, just keep it disabled. This bar will always be visible and will not scale when you eat.");
             customEitrBar.SettingChanged += (_, _) => CustomEitrBar_SettingChanged();
             RemoveOldConfigValue<int>(new ConfigDefinition(sectionName, "customSpoilerBarRotation"));
-
-            customBarTextSize = Config.Bind(sectionName, nameof(customBarTextSize), 14, "Font size of the text on the custom bars.");
 
             //
             // Character Inventory

--- a/BetterUI/Main.cs
+++ b/BetterUI/Main.cs
@@ -132,7 +132,7 @@ namespace BetterUI
             sectionName = "1 - Player HUD (Requires Logout)";
 
             var editingDefault = GetOldOrDefaultConfigValue(new ConfigDefinition("1 - Player HUD", nameof(enablePlayerHudEditing)), true);
-            enablePlayerHudEditing = Config.Bind(sectionName, nameof(enablePlayerHudEditing), editingDefault, "Enable the ability to edit the Player HUD by pressing a hotkey.");
+            enablePlayerHudEditing = Config.Bind(sectionName, nameof(enablePlayerHudEditing), editingDefault, "Enable the ability to edit the player HUD by pressing a hotkey.");
 
             var healthDefault = GetOldOrDefaultConfigValue(new ConfigDefinition("1 - Player HUD", "useCustomHealthBar"), false);
             healthDefault |= GetOldOrDefaultConfigValue(new ConfigDefinition("1 - Player HUD (Requires Logout)", "useCustomHealthBar"), false);
@@ -166,25 +166,25 @@ namespace BetterUI
 
             var wasColorOnDefault = GetOldOrDefaultConfigValue(new ConfigDefinition(sectionName, "showDurabilityColor"), true);
             var colorDefault = GetOldOrDefaultConfigValue(new ConfigDefinition(sectionName, "durabilityColorPalette"), 0);
-            durabilityBarColorPalette = Config.Bind(sectionName, nameof(durabilityBarColorPalette), IntToDurabilityBarStyle(wasColorOnDefault, colorDefault), "Change durabilty bar colors. Options: 0 = Green, Yellow, Orange, Red, 1 = White, Light Yellow, Light Cyan, Blue.");
+            durabilityBarColorPalette = Config.Bind(sectionName, nameof(durabilityBarColorPalette), IntToDurabilityBarStyle(wasColorOnDefault, colorDefault), "Change durability bar colors. Options: 0 = Green, Yellow, Orange, Red, 1 = White, Light Yellow, Light Cyan, Blue.");
 
             showItemStars = Config.Bind(sectionName, nameof(showItemStars), true, "Show item quality as stars.");
 
-            showCustomCharInfo = Config.Bind(sectionName, nameof(showCustomCharInfo), true, "Show Deaths, Builds, and Crafts stats on character selection screen. Also shows the Kills stat if something increases it.");
+            showCustomCharInfo = Config.Bind(sectionName, nameof(showCustomCharInfo), true, "Show Deaths, Builds, and Crafts stats on character selection screen. Also shows the Kills stat if something increases it (the base game doesn't).");
 
             showCustomTooltips = Config.Bind(sectionName, nameof(showCustomTooltips), true, "Show more info on inventory item tooltips. Disable this if using Epic Loot.");
 
             showCombinedItemStats = Config.Bind(sectionName, nameof(showCombinedItemStats), true, "Show all item stats when mouse is hovered over armor amount.");
 
-            iconScaleSize = Config.Bind(sectionName, nameof(iconScaleSize), 0.75f, "Scale item icon by this factor. Ex. 0.75 makes them 75% of original size.");
+            iconScaleSize = Config.Bind(sectionName, nameof(iconScaleSize), 1f, "Scale item icon by this factor. Ex. 0.75 makes them 75% of their original size.");
 
             //
             // Skills UI
             sectionName = "3 - Character Skills";
 
-            customSkillUI = Config.Bind(sectionName, nameof(customSkillUI), false, "Toggle the use of custom skills UI.");
+            customSkillUI = Config.Bind(sectionName, nameof(customSkillUI), false, "Toggle the use of the custom skills UI.");
 
-            skillUITextSize = Config.Bind(sectionName, nameof(skillUITextSize), 14, "Select text size on skills UI.");
+            skillUITextSize = Config.Bind(sectionName, nameof(skillUITextSize), 14, "Select text size of the skills UI.");
 
             //
             // Hover Text
@@ -209,13 +209,13 @@ namespace BetterUI
             // Character XP
             sectionName = "5 - Character XP";
 
-            showCharacterXP = Config.Bind(sectionName, nameof(showCharacterXP), true, "Enable Character XP. This combines all skill levels to show overall character progress.");
+            showCharacterXP = Config.Bind(sectionName, nameof(showCharacterXP), true, "Enable character XP. This combines all skill levels to show overall character progress.");
 
             showXPNotifications = Config.Bind(sectionName, nameof(showXPNotifications), true, "Show whenever you gain xp from actions.");
 
             notificationTextSizeXP = Config.Bind(sectionName, nameof(notificationTextSizeXP), 14, "XP notification font size.");
 
-            extendedXPNotification = Config.Bind(sectionName, nameof(extendedXPNotification), true, "Extend notification with: (xp gained) [current/overall xp].");
+            extendedXPNotification = Config.Bind(sectionName, nameof(extendedXPNotification), false, "Extend notification with: (xp gained) [current/overall xp].");
 
             skipRunningSkillNotifications = Config.Bind(sectionName, nameof(skipRunningSkillNotifications), true, "Whether to ignore xp gain notifications for the running skill.");
 
@@ -223,7 +223,7 @@ namespace BetterUI
             sectionName = "5 - Character XP (Requires Logout)";
 
             var expBarDefault = GetOldOrDefaultConfigValue(new ConfigDefinition("5 - Character XP", nameof(showCharacterXpBar)), true);
-            showCharacterXpBar = Config.Bind(sectionName, nameof(showCharacterXpBar), expBarDefault, "Show Character XP Bar on the bottom of the screen. Character XP must be enabled.");
+            showCharacterXpBar = Config.Bind(sectionName, nameof(showCharacterXpBar), expBarDefault, "Show Character XP bar on the bottom of the screen. Character XP must be enabled.");
 
             //
             // Enemy HUD
@@ -233,33 +233,33 @@ namespace BetterUI
 
             useCustomAlertedStatus = Config.Bind(sectionName, nameof(useCustomAlertedStatus), true, "Hide the vanilla alerted icons above the enemy health bar and instead change the color of the name based on the alerted status.");
 
-            showEnemyHPText = Config.Bind(sectionName, nameof(showEnemyHPText), true, "Show the text with HP amount on enemies health bar.");
+            showEnemyHPText = Config.Bind(sectionName, nameof(showEnemyHPText), true, "Show the text with HP amount on enemy health bars.");
 
             var enemyLevelStyleDefault = GetOldOrDefaultConfigValue(new ConfigDefinition(sectionName, "enemyLvlStyle"), 0);
-            enemyLevelStyle = Config.Bind(sectionName, nameof(enemyLevelStyle), IntToEnemyLevelStyle(enemyLevelStyleDefault), "Choose how enemy lvl is shown. 0 = Default (stars) | 1 = Prefix before name (Lv. 1) | 2 = Both.");
+            enemyLevelStyle = Config.Bind(sectionName, nameof(enemyLevelStyle), IntToEnemyLevelStyle(enemyLevelStyleDefault), "Choose how enemy level is shown. 0 = Default (stars) | 1 = Prefix before name (Lv. 1) | 2 = Both.");
 
             enemyNameTextSize = Config.Bind(sectionName, nameof(enemyNameTextSize), 14, "Font size of the name on the enemy.");
 
             enemyHPTextSize = Config.Bind(sectionName, nameof(enemyHPTextSize), 10, "Font size of the HP text on the enemy health bar.");
 
-            showPlayerHPText = Config.Bind(sectionName, nameof(showPlayerHPText), true, "Show the health numbers on other player's health bar in Multiplayer.");
+            showPlayerHPText = Config.Bind(sectionName, nameof(showPlayerHPText), true, "Show the health numbers on other player's health bar in multiplayer.");
 
-            showLocalPlayerEnemyHud = Config.Bind(sectionName, nameof(showLocalPlayerEnemyHud), false, "Show the EnemyHud/HealthBar for your player.");
+            showLocalPlayerEnemyHud = Config.Bind(sectionName, nameof(showLocalPlayerEnemyHud), false, "Show the enemy HUD/ health Bar for your player.");
             showLocalPlayerEnemyHud.SettingChanged += (_, _) => BetterEnemyHud.ShowLocalPlayerEnemyHudConfigChanged();
 
-            playerHPTextSize = Config.Bind(sectionName, nameof(playerHPTextSize), 10, "The size of the font to display on other player's health bar in Multiplayer.");
+            playerHPTextSize = Config.Bind(sectionName, nameof(playerHPTextSize), 10, "The size of the font to display on other player's health bar in multiplayer.");
 
-            bossHPTextSize = Config.Bind(sectionName, nameof(bossHPTextSize), 14, "The size of the font to display on the Boss's health bar.");
+            bossHPTextSize = Config.Bind(sectionName, nameof(bossHPTextSize), 14, "The size of the font to display on the boss's health bar.");
 
             makeTamedHPGreen = Config.Bind(sectionName, nameof(makeTamedHPGreen), true, "Make the health bar for tamed creatures green instead of red.");
 
-            maxShowDistance = Config.Bind(sectionName, nameof(maxShowDistance), 1f, "How far you will see enemy HP Bar. This is an multiplier, 1 = game default, 2 = 2x default.");
+            maxShowDistance = Config.Bind(sectionName, nameof(maxShowDistance), 1f, "How far you will see enemy HP Bar. This is a multiplier, 1 is game default, 2 is twice as far (valid range: 0 to 3).");
 
             //
             // Map
             sectionName = "7 - Map";
 
-            mapPinScaleSize = Config.Bind(sectionName, nameof(mapPinScaleSize), 1f, "Scale map pins by this factor. Ex. 1.5 makes the 150% of original size.");
+            mapPinScaleSize = Config.Bind(sectionName, nameof(mapPinScaleSize), 1f, "Scale map pins by this factor. Ex. 1.5 makes them 150% of their original size.");
 
             //
             // Debug

--- a/BetterUI/Main.cs
+++ b/BetterUI/Main.cs
@@ -33,10 +33,12 @@ namespace BetterUI
         public static ConfigEntry<KeyCode> modKeySecondary;
         public static ConfigEntry<bool> useCustomHealthBar;
         public static ConfigEntry<bool> useCustomStaminaBar;
+        public static ConfigEntry<bool> useCustomSpoilerBar;
         public static ConfigEntry<bool> useCustomFoodBar;
-        public static ConfigEntry<int> healthBarRotation;
-        public static ConfigEntry<int> staminaBarRotation;
-        public static ConfigEntry<int> foodBarRotation;
+        public static ConfigEntry<int> customHealthBarRotation;
+        public static ConfigEntry<int> customStaminaBarRotation;
+        public static ConfigEntry<int> customSpoilerBarRotation;
+        public static ConfigEntry<int> customFoodBarRotation;
 
         // Player Inventory
         public static ConfigEntry<bool> showDurabilityColor;
@@ -98,146 +100,152 @@ namespace BetterUI
         }
         public void Awake()
         {
+            string sectionName;
+
+            // Don't be tempted to rename the sections. That resets all its config values for every user
+            // The same goes for moving items between sections
+            // That's also why there is no section number counter
+
+
             // Player HUD
-            enablePlayerHudEditing = Config.Bind("1 - Player HUD", nameof(enablePlayerHudEditing), true, "Enable the ability to edit the Player HUD by pressing a hotkey. (REQUIRES RESTART)");
+            sectionName = "1 - Player HUD";
 
-            togglePlayerHudEditModeKey = Config.Bind("1 - Player HUD", nameof(togglePlayerHudEditModeKey), KeyCode.F7, "Key used to toggle Player HUD editing mode.");
+            togglePlayerHudEditModeKey = Config.Bind(sectionName, nameof(togglePlayerHudEditModeKey), KeyCode.F7,
+                "Key used to toggle Player HUD editing mode. Accepted values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
 
-            modKeyPrimary = Config.Bind("1 - Player HUD", nameof( modKeyPrimary), KeyCode.Mouse0,
-              "Button needed to hold down to change HUD position. Accepted values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
+            modKeyPrimary = Config.Bind(sectionName, nameof(modKeyPrimary), KeyCode.Mouse0,
+                "Key needed to hold down to change HUD position. Accepted values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
 
-            modKeySecondary = Config.Bind("1 - Player HUD", nameof(modKeySecondary), KeyCode.LeftControl,
-              "Button needed to hold down to change element dimensions. Accepted Values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
+            modKeySecondary = Config.Bind(sectionName, nameof(modKeySecondary), KeyCode.LeftControl,
+                "Key needed to hold down to change element dimensions. Accepted Values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
 
-            useCustomHealthBar = Config.Bind("1 - Player HUD", nameof(useCustomHealthBar), false, "Resizable, rotatable HP bar. This bar will always be the same size and will not scale when you eat. (REQUIRES RESTART)");
+            // Player HUD RESTART
+            sectionName = "1 - Player HUD (Requires Logout)";
+
+            enablePlayerHudEditing = Config.Bind(sectionName, nameof(enablePlayerHudEditing), true, "Enable the ability to edit the Player HUD by pressing a hotkey.");
+
+            useCustomHealthBar = Config.Bind(sectionName, nameof(useCustomHealthBar), false, $"Resizable, rotatable HP bar. This bar will always be the same size and will not scale when you eat. Will also disable the default food bar, so use {nameof(useCustomFoodBar)}.");
             
-            useCustomStaminaBar = Config.Bind("1 - Player HUD", nameof(useCustomStaminaBar), false, "Resizable, rotatable Stamina bar. This bar will always be visible and will not scale when you eat. (REQUIRES RESTART)");
-            
-            useCustomFoodBar = Config.Bind("1 - Player HUD", nameof(useCustomFoodBar), false, "Resizable, rotatable Food Bar. (REQUIRES RESTART)");
+            useCustomStaminaBar = Config.Bind(sectionName, nameof(useCustomStaminaBar), false, "Resizable, rotatable Stamina bar. This bar will always be visible and will not scale when you eat.");
 
-            healthBarRotation = Config.Bind("1 - Player HUD", nameof(healthBarRotation), 0, "Rotate healthbar in degrees  (REQUIRES RESTART)");
+            useCustomSpoilerBar = Config.Bind(sectionName, nameof(useCustomSpoilerBar), false, "Resizable, rotatable bar for the new spoiler resource. This bar will always be visible and will not scale when you eat.");
 
-            staminaBarRotation = Config.Bind("1 - Player HUD", nameof(staminaBarRotation), 90, "Rotate staminabar in degrees  (REQUIRES RESTART)");
+            useCustomFoodBar = Config.Bind(sectionName, nameof(useCustomFoodBar), false, $"Resizable, rotatable Food Bar. Requires {nameof(useCustomHealthBar)}.");
 
-            foodBarRotation = Config.Bind("1 - Player HUD", nameof(foodBarRotation), 90, "Rotate foodbar in degrees  (REQUIRES RESTART)" +
-                "" +
-                "");
-            
+            customHealthBarRotation = Config.Bind(sectionName, nameof(customHealthBarRotation), 90, "Rotate healthbar in degrees.");
+
+            customStaminaBarRotation = Config.Bind(sectionName, nameof(customStaminaBarRotation), 90, "Rotate staminabar in degrees.");
+
+            customSpoilerBarRotation = Config.Bind(sectionName, nameof(customSpoilerBarRotation), 90, "Rotate bar for the new spoiler resource in degrees.");
+
+            customFoodBarRotation = Config.Bind(sectionName, nameof(customFoodBarRotation), 90, "Rotate foodbar in degrees.");
+
 
             // Character Inventory
-            showDurabilityColor = Config.Bind("2 - Character Inventory", nameof(showDurabilityColor), true, "Show colored durability bars for items");
+            sectionName = "2 - Character Inventory";
 
-            durabilityColorPalette = Config.Bind("2 - Character Inventory", nameof(durabilityColorPalette), 0, "Change Durabilty bar colors. Options: 0=Green,Yellow,Orange,Red, 1=White,Light Yellow,Light Cyan,Blue. ");
+            showDurabilityColor = Config.Bind(sectionName, nameof(showDurabilityColor), true, "Show colored durability bars for items.");
 
-            showItemStars = Config.Bind("2 - Character Inventory", nameof(showItemStars), true, "Show item quality as stars");
+            durabilityColorPalette = Config.Bind(sectionName, nameof(durabilityColorPalette), 0, "Change Durabilty bar colors. Options: 0 = Green, Yellow, Orange, Red, 1 = White, Light Yellow, Light Cyan, Blue.");
 
-            showCustomCharInfo = Config.Bind("2 - Character Inventory", nameof(showCustomCharInfo), true, "Show Kills, Deaths, Builds, and Crafts stats on character selection screen");
+            showItemStars = Config.Bind(sectionName, nameof(showItemStars), true, "Show item quality as stars.");
 
-            showCustomTooltips = Config.Bind("2 - Character Inventory", nameof(showCustomTooltips), true, "Show more info on inventory item tooltips. Disable this is using Epic Loot.");
+            showCustomCharInfo = Config.Bind(sectionName, nameof(showCustomCharInfo), true, "Show Deaths, Builds, and Crafts stats on character selection screen. Also shows the Kills stat if something increases it.");
 
-            showCombinedItemStats = Config.Bind("2 - Character Inventory", nameof(showCombinedItemStats), true, "Show all item stats when mouse is hovered over armor amount.");
+            showCustomTooltips = Config.Bind(sectionName, nameof(showCustomTooltips), true, "Show more info on inventory item tooltips. Disable this is using Epic Loot.");
 
-            iconScaleSize = Config.Bind("2 - Character Inventory", nameof(iconScaleSize), 0.75f, "Scale item icon by this factor. Ex. 0.75 makes them 75% of original size");
+            showCombinedItemStats = Config.Bind(sectionName, nameof(showCombinedItemStats), true, "Show all item stats when mouse is hovered over armor amount.");
+
+            iconScaleSize = Config.Bind(sectionName, nameof(iconScaleSize), 0.75f, "Scale item icon by this factor. Ex. 0.75 makes them 75% of original size.");
 
 
             // Skills UI
-            customSkillUI = Config.Bind("3 - Character Skills", nameof(customSkillUI), false, "Toggle the use of custom skills UI");
+            sectionName = "3 - Character Skills";
 
-            skillUITextSize = Config.Bind("3 - Character Skills", nameof(skillUITextSize), 14, "Select text size on skills UI");
+            customSkillUI = Config.Bind(sectionName, nameof(customSkillUI), false, "Toggle the use of custom skills UI.");
+
+            skillUITextSize = Config.Bind(sectionName, nameof(skillUITextSize), 14, "Select text size on skills UI.");
 
 
             // Hover Text
-            timeLeftStyleFermenter = Config.Bind("4 - Hover Text", nameof(timeLeftStyleFermenter), 2, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left");
+            sectionName = "4 - Hover Text";
 
-            timeLeftStylePlant = Config.Bind("4 - Hover Text", nameof(timeLeftStylePlant), 2, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left");
+            timeLeftStyleFermenter = Config.Bind(sectionName, nameof(timeLeftStyleFermenter), 2, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left.");
 
-            timeLeftStyleCookingStation = Config.Bind("4 - Hover Text", nameof(timeLeftStyleCookingStation), 2, "Select duration display. 0 = Default, 1= % Done, 2 = min:sec left");
+            timeLeftStylePlant = Config.Bind(sectionName, nameof(timeLeftStylePlant), 2, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left.");
 
-            chestHasRoomStyle = Config.Bind("4 - Hover Text", nameof(chestHasRoomStyle), 2, "Select how chest emptyness is displayed. 0 = Default | 1 = % | 2 = items / max_room. | 3 = free slots ");
+            timeLeftStyleCookingStation = Config.Bind(sectionName, nameof(timeLeftStyleCookingStation), 2, "Select duration display. 0 = Default, 1= % Done, 2 = min:sec left.");
+
+            chestHasRoomStyle = Config.Bind(sectionName, nameof(chestHasRoomStyle), 2, "Select how chest emptyness is displayed. 0 = Default | 1 = % | 2 = items / max_room. | 3 = free slots.");
 
 
             // Character XP
-            showCharacterXP = Config.Bind("5 - Character XP", nameof(showCharacterXP), true, "Enable Character XP. This combines all skill levels to show overall character progress.");
+            sectionName = "5 - Character XP";
 
-            showCharacterXpBar = Config.Bind("5 - Character XP", nameof(showCharacterXpBar), true, "Show Character XP Bar on the bottom of the screen. Character XP must be enabled.");
+            showCharacterXP = Config.Bind(sectionName, nameof(showCharacterXP), true, "Enable Character XP. This combines all skill levels to show overall character progress.");
 
-            showCharacterXpBar.Value = showCharacterXP.Value && showCharacterXpBar.Value;
+            showXPNotifications = Config.Bind(sectionName, nameof(showXPNotifications), true, "Show whenever you gain xp from actions.");
 
-            showXPNotifications = Config.Bind("5 - Character XP", nameof(showXPNotifications), true, "Show whenever you gain xp from actions.");
+            notificationTextSizeXP = Config.Bind(sectionName, nameof(notificationTextSizeXP), 14, "XP notification font size.");
 
-            notificationTextSizeXP = Config.Bind("5 - Character XP", nameof(notificationTextSizeXP), 14, "XP notification font size.");
+            extendedXPNotification = Config.Bind(sectionName, nameof(extendedXPNotification), true, "Extend notification with: (xp gained) [current/overall xp].");
 
-            extendedXPNotification = Config.Bind("5 - Character XP", nameof(extendedXPNotification), true, "Extend notification with: (xp gained) [current/overall xp]");
+            // Character XP RESTART
+            sectionName = "5 - Character XP (Requires Logout)";
+
+            showCharacterXpBar = Config.Bind(sectionName, nameof(showCharacterXpBar), true, "Show Character XP Bar on the bottom of the screen. Character XP must be enabled.");
 
 
             // Enemy HUD
-            customEnemyHud = Config.Bind("6 - Enemy HUD", nameof(customEnemyHud), true, "Enable custom enemy HUD changes. If this is set to false, all options in this section will be disabled.");
+            sectionName = "6 - Enemy HUD";
 
-            useCustomAlertedStatus = Config.Bind("6 - Enemy HUD", nameof(useCustomAlertedStatus), true, "Hide the vanilla alerted icons above the enemy health bar and instead change the color of the name based on the alerted status.");
+            customEnemyHud = Config.Bind(sectionName, nameof(customEnemyHud), true, "Enable custom enemy HUD changes. If this is set to false, all options in this section will be disabled.");
 
-            showEnemyHPText = Config.Bind("6 - Enemy HUD", nameof(showEnemyHPText), true, "Show the text with HP amount on enemies health bar.");
+            useCustomAlertedStatus = Config.Bind(sectionName, nameof(useCustomAlertedStatus), true, "Hide the vanilla alerted icons above the enemy health bar and instead change the color of the name based on the alerted status.");
 
-            enemyLvlStyle = Config.Bind("6 - Enemy HUD", nameof(enemyLvlStyle), 0, "Choose how enemy lvl is shown. 0 = Default(stars) | 1 = Prefix before name (Lv. 1) | 2 = Both");
+            showEnemyHPText = Config.Bind(sectionName, nameof(showEnemyHPText), true, "Show the text with HP amount on enemies health bar.");
 
-            enemyNameTextSize = Config.Bind("6 - Enemy HUD", nameof(enemyNameTextSize), 14, "Font Size of the Name on the enemy");
+            enemyLvlStyle = Config.Bind(sectionName, nameof(enemyLvlStyle), 0, "Choose how enemy lvl is shown. 0 = Default (stars) | 1 = Prefix before name (Lv. 1) | 2 = Both.");
 
-            enemyHPTextSize = Config.Bind("6 - Enemy HUD", nameof(enemyHPTextSize), 10, "Font size of the HP text on the enemy health bar.");
+            enemyNameTextSize = Config.Bind(sectionName, nameof(enemyNameTextSize), 14, "Font size of the name on the enemy.");
 
-            showPlayerHPText = Config.Bind("6 - Enemy HUD", nameof(showPlayerHPText), true, "Show the health numbers on other player's health bar in Multiplayer.");
+            enemyHPTextSize = Config.Bind(sectionName, nameof(enemyHPTextSize), 10, "Font size of the HP text on the enemy health bar.");
 
-            showLocalPlayerEnemyHud = Config.Bind("6 - Enemy HUD", nameof(showLocalPlayerEnemyHud), false, "Show the EnemyHud/HealthBar for your player.");
+            showPlayerHPText = Config.Bind(sectionName, nameof(showPlayerHPText), true, "Show the health numbers on other player's health bar in Multiplayer.");
+
+            showLocalPlayerEnemyHud = Config.Bind(sectionName, nameof(showLocalPlayerEnemyHud), false, "Show the EnemyHud/HealthBar for your player.");
             showLocalPlayerEnemyHud.SettingChanged += (_, _) => BetterEnemyHud.ShowLocalPlayerEnemyHudConfigChanged();
 
-            playerHPTextSize = Config.Bind("6 - Enemy HUD", nameof(playerHPTextSize), 10, "The size of the font to display on other player's health bar in Multiplayer.");
+            playerHPTextSize = Config.Bind(sectionName, nameof(playerHPTextSize), 10, "The size of the font to display on other player's health bar in Multiplayer.");
 
-            bossHPTextSize = Config.Bind("6 - Enemy HUD", nameof(bossHPTextSize), 14, "The size of the font To display on the Boss's health bar.");
+            bossHPTextSize = Config.Bind(sectionName, nameof(bossHPTextSize), 14, "The size of the font to display on the Boss's health bar.");
 
-            makeTamedHPGreen = Config.Bind("6 - Enemy HUD", nameof(makeTamedHPGreen), true, "Make the health bar for tamed creatures green instead of red.");
+            makeTamedHPGreen = Config.Bind(sectionName, nameof(makeTamedHPGreen), true, "Make the health bar for tamed creatures green instead of red.");
 
-            maxShowDistance = Config.Bind("6 - Enemy HUD", nameof(maxShowDistance), 1f, "How far you will see enemy HP Bar. This is an multiplier, 1 = game default. 2 = 2x default");
+            maxShowDistance = Config.Bind(sectionName, nameof(maxShowDistance), 1f, "How far you will see enemy HP Bar. This is an multiplier, 1 = game default, 2 = 2x default.");
 
 
             // Map
-            mapPinScaleSize = Config.Bind("7 - Map", nameof(mapPinScaleSize), 1f, "Scale map pins by this factor. Ex. 1.5 makes the 150% of original size.");
+            sectionName = "7 - Map";
+
+            mapPinScaleSize = Config.Bind(sectionName, nameof(mapPinScaleSize), 1f, "Scale map pins by this factor. Ex. 1.5 makes the 150% of original size.");
+
 
             // Debug
-            isDebug = Config.Bind("8 - Debug", nameof(isDebug), false, "Enable debug logging");
+            sectionName = "8 - Debug";
 
-            /* =======================
-             *         xDataUI
-             * =======================
-             */
-            uiData = Config.Bind("9 - xDataUI", nameof(uiData), "none", "This is your customized UI info. (Edit to none, if having issues with UI)");
-            /*
-            showXPNotifications = Config.Bind("UI", "ShowXPNotifications", true, "Show when you gain xp from actions.");
-            extendedXPNotification = Config.Bind("UI", "extendedXPNotification", true, "Extend notification with: (xp gained) [current/overall xp]");
-            notificationTextSize = Config.Bind("UI", "notificationTextSize", 14, "Edit XP notification font size.");
-            customSkillUI = Config.Bind("UI", "useCustomSkillUI", true, "Toggle the use of custom skills UI");
-            skillUITextSize = Config.Bind("UI", "skillUITextSize", 14, "Select text size on skills UI");
-            showCustomCharInfo = Config.Bind("UI", "showCustomCharInfo", true, "Toggle the visibility of custom info on character selection");
-            showCombinedItemStats = Config.Bind("UI", "showCombinedItemStats", true, "Show all item stats when mouse is hovered over armour amount.");
-            timeLeftStyleFermenter = Config.Bind("UI", "timeLeftStyleFermenter", 2, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left");
-            timeLeftStylePlant = Config.Bind("UI", "timeLeftStylePlant", 2, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left");
-            timeLeftStyleCookingStation = Config.Bind("UI", "timeLeftStyleCookingStation", 2, "Select duration display. 0 = Default, 1= % Done, 2 = min:sec left");
-            chestHasRoomStyle = Config.Bind("UI", "chestHasRoomStyle", 2, "Select how chest emptyness is displayed. 0 = Default | 1 = % | 2 = items / max_room. | 3 = free slots ");
+            isDebug = Config.Bind(sectionName, nameof(isDebug), false, "Enable debug logging.");
 
-            showDurabilityColor = Config.Bind("Item", "ShowDurabilityColor", true, "Show colored durability bars");
-            showItemStars = Config.Bind("Item", "showItemStars", true, "Show item quality as stars");
-            showCustomTooltips = Config.Bind("Item", "showCustomTooltips", true, "Show customized tooltips.");
-            iconScaleSize = Config.Bind("Item", "ScaleSize", 0.75f, "Scale item icon by this factor. Ex. 0.75 makes them 75% of original size");
 
-            customEnemyHud = Config.Bind("HUD", "useCustomEnemyHud", true, "Toggle the use of custom enemy hud");
-            hideEnemyHPText = Config.Bind("HUD", "hideEnemyHPText", false, "Toggle if you want to hide the text with HP amount");
-            enemyLvlStyle = Config.Bind("HUD", "enemyLvlStyle", 1, "Choose how enemy lvl is shown. 0 = Default(stars) | 1 = Prefix before name (Lv. 1) | 2 = Both");
-            enemyHudTextSize = Config.Bind("HUD", "enemyHudTextSize", 14, "Select Text size on enemyHud");
-            maxShowDistance = Config.Bind("HUD", "MaxShowDistance", 1f, "How far you will see enemy HP Bar. This is an multiplier, 1 = game default. 2 = 2x default");
-            mapPinScaleSize = Config.Bind("HUD", "mapPinSize", 1f, "Scale map pins by this factor. Ex. 1.5 makes the 150% of original size.");
-            */
+            // xDataUI
+            sectionName = "9 - xDataUI";
+            uiData = Config.Bind(sectionName, nameof(uiData), "none", "This is your customized UI info. Edit to none, if having issues or wanting to reset positions.");
         }
         public void Start()
         {
             harmony.PatchAll(assembly);
         }
+
         /*
         public void OnDestroy()
         {

--- a/BetterUI/Main.cs
+++ b/BetterUI/Main.cs
@@ -4,6 +4,9 @@ using BepInEx.Logging;
 using BetterUI.GameClasses;
 
 using HarmonyLib;
+using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using UnityEngine;
 
@@ -20,29 +23,24 @@ namespace BetterUI
           GUID = AUTHOR + "_" + MODNAME,
           VERSION = "2.2.3";
 
-
         internal static ManualLogSource log;
         internal readonly Harmony harmony;
         internal readonly Assembly assembly;
 
-        
         // Player HUD
         public static ConfigEntry<bool> enablePlayerHudEditing;
+
         public static ConfigEntry<KeyCode> togglePlayerHudEditModeKey;
         public static ConfigEntry<KeyCode> modKeyPrimary;
         public static ConfigEntry<KeyCode> modKeySecondary;
-        public static ConfigEntry<bool> useCustomHealthBar;
-        public static ConfigEntry<bool> useCustomStaminaBar;
-        public static ConfigEntry<bool> useCustomSpoilerBar;
-        public static ConfigEntry<bool> useCustomFoodBar;
-        public static ConfigEntry<int> customHealthBarRotation;
-        public static ConfigEntry<int> customStaminaBarRotation;
-        public static ConfigEntry<int> customSpoilerBarRotation;
-        public static ConfigEntry<int> customFoodBarRotation;
+        public static ConfigEntry<CustomBarState> customHealthBar;
+        public static ConfigEntry<CustomBarState> customStaminaBar;
+        public static ConfigEntry<CustomBarState> customEitrBar;
+        public static ConfigEntry<CustomBarState> customFoodBar;
+        public static ConfigEntry<int> customBarTextSize;
 
         // Player Inventory
-        public static ConfigEntry<bool> showDurabilityColor;
-        public static ConfigEntry<int> durabilityColorPalette;
+        public static ConfigEntry<DurabilityBarStyle> durabilityBarColorPalette;
         public static ConfigEntry<bool> showItemStars;
         public static ConfigEntry<bool> showCustomCharInfo;
         public static ConfigEntry<bool> showCustomTooltips;
@@ -51,25 +49,31 @@ namespace BetterUI
 
         // Skill UI
         public static ConfigEntry<bool> customSkillUI;
+
         public static ConfigEntry<int> skillUITextSize;
 
         // HoverTexts
-        public static ConfigEntry<int> timeLeftStyleFermenter;
-        public static ConfigEntry<int> timeLeftStylePlant;
-        public static ConfigEntry<int> timeLeftStyleCookingStation;
-        public static ConfigEntry<int> chestHasRoomStyle;
-        
+        public static ConfigEntry<TimeLeftStyle> timeLeftHoverTextFermenter;
+
+        public static ConfigEntry<TimeLeftStyle> timeLeftHoverTextPlant;
+        public static ConfigEntry<TimeLeftStyle> timeLeftHoverTextCookingStation;
+        public static ConfigEntry<TimeLeftStyle> timeLeftHoverTextBeeHive;
+        public static ConfigEntry<ChestHasRoomStyle> chestHasRoomHoverText;
+
         // Character XP
         public static ConfigEntry<bool> showCharacterXP;
+
         public static ConfigEntry<bool> showCharacterXpBar;
         public static ConfigEntry<bool> showXPNotifications;
         public static ConfigEntry<bool> extendedXPNotification;
+        public static ConfigEntry<bool> skipRunningSkillNotifications;
         public static ConfigEntry<int> notificationTextSizeXP;
 
         // Enemy HUD
         public static ConfigEntry<bool> customEnemyHud;
+
         public static ConfigEntry<bool> showEnemyHPText;
-        public static ConfigEntry<int> enemyLvlStyle;
+        public static ConfigEntry<EnemyLevelStyle> enemyLevelStyle;
         public static ConfigEntry<int> enemyNameTextSize;
         public static ConfigEntry<int> enemyHPTextSize;
         public static ConfigEntry<int> playerHPTextSize;
@@ -80,9 +84,9 @@ namespace BetterUI
         public static ConfigEntry<float> maxShowDistance;
         public static ConfigEntry<bool> useCustomAlertedStatus;
 
-        // Map        
+        // Map
         public static ConfigEntry<float> mapPinScaleSize;
-        
+
         // xUIData
         public static ConfigEntry<string> uiData;
 
@@ -91,13 +95,13 @@ namespace BetterUI
 
         #endregion
 
-
         public Main()
         {
             log = Logger;
             harmony = new Harmony(GUID);
             assembly = Assembly.GetExecutingAssembly();
         }
+
         public void Awake()
         {
             string sectionName;
@@ -106,7 +110,7 @@ namespace BetterUI
             // The same goes for moving items between sections
             // That's also why there is no section number counter
 
-
+            //
             // Player HUD
             sectionName = "1 - Player HUD";
 
@@ -114,51 +118,65 @@ namespace BetterUI
                 "Key used to toggle Player HUD editing mode. Accepted values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
 
             modKeyPrimary = Config.Bind(sectionName, nameof(modKeyPrimary), KeyCode.Mouse0,
-                "Key needed to hold down to change HUD position. Accepted values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
+                "Key needed to be held down to change an elements position by moving the mouse, as well as its rotation with the mouse wheel if supported. Accepted values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
 
             modKeySecondary = Config.Bind(sectionName, nameof(modKeySecondary), KeyCode.LeftControl,
-                "Key needed to hold down to change element dimensions. Accepted Values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
+                "Key needed to be held down to change an elements scale with the mouse wheel, as well as its X and Y dimensions by moving the mouse. Accepted Values: https://docs.unity3d.com/ScriptReference/KeyCode.html");
 
             // Player HUD RESTART
             sectionName = "1 - Player HUD (Requires Logout)";
 
-            enablePlayerHudEditing = Config.Bind(sectionName, nameof(enablePlayerHudEditing), true, "Enable the ability to edit the Player HUD by pressing a hotkey.");
+            var editingDefault = GetOldOrDefaultConfigValue(new ConfigDefinition("1 - Player HUD", nameof(enablePlayerHudEditing)), true);
+            enablePlayerHudEditing = Config.Bind(sectionName, nameof(enablePlayerHudEditing), editingDefault, "Enable the ability to edit the Player HUD by pressing a hotkey.");
 
-            useCustomHealthBar = Config.Bind(sectionName, nameof(useCustomHealthBar), false, $"Resizable, rotatable HP bar. This bar will always be the same size and will not scale when you eat. Will also disable the default food bar, so use {nameof(useCustomFoodBar)}.");
-            
-            useCustomStaminaBar = Config.Bind(sectionName, nameof(useCustomStaminaBar), false, "Resizable, rotatable Stamina bar. This bar will always be visible and will not scale when you eat.");
+            var healthDefault = GetOldOrDefaultConfigValue(new ConfigDefinition("1 - Player HUD", "useCustomHealthBar"), false);
+            healthDefault |= GetOldOrDefaultConfigValue(new ConfigDefinition("1 - Player HUD (Requires Logout)", "useCustomHealthBar"), false);
+            customHealthBar = Config.Bind(sectionName, nameof(customHealthBar), healthDefault ? CustomBarState.on0Degrees : CustomBarState.off, $"Resizable, rotatable HP bar. This bar will always be the same size and will not scale when you eat. Will also disable the default food bar, so use {nameof(customFoodBar)}.");
+            customHealthBar.SettingChanged += (_, _) => CustomHealthBar_SettingChanged();
+            RemoveOldConfigValue<int>(new ConfigDefinition("1 - Player HUD", "healthBarRotation"));
+            RemoveOldConfigValue<int>(new ConfigDefinition("1 - Player HUD (Requires Logout)", "customHealthBarRotation"));
 
-            useCustomSpoilerBar = Config.Bind(sectionName, nameof(useCustomSpoilerBar), false, "Resizable, rotatable bar for the new spoiler resource. This bar will always be visible and will not scale when you eat.");
+            var staminaDefault = GetOldOrDefaultConfigValue(new ConfigDefinition("1 - Player HUD", "useCustomStaminaBar"), false);
+            staminaDefault |= GetOldOrDefaultConfigValue(new ConfigDefinition("1 - Player HUD (Requires Logout)", "useCustomStaminaBar"), false);
+            customStaminaBar = Config.Bind(sectionName, nameof(customStaminaBar), staminaDefault ? CustomBarState.on0Degrees : CustomBarState.off, "Resizable, rotatable stamina bar. This bar will always be visible and will not scale when you eat.");
+            customStaminaBar.SettingChanged += (_, _) => CustomStaminaBar_SettingChanged();
+            RemoveOldConfigValue<int>(new ConfigDefinition("1 - Player HUD", "staminaBarRotation"));
+            RemoveOldConfigValue<int>(new ConfigDefinition("1 - Player HUD (Requires Logout)", "customStaminaBarRotation"));
 
-            useCustomFoodBar = Config.Bind(sectionName, nameof(useCustomFoodBar), false, $"Resizable, rotatable Food Bar. Requires {nameof(useCustomHealthBar)}.");
+            var foodDefault = GetOldOrDefaultConfigValue(new ConfigDefinition("1 - Player HUD", "useCustomFoodBar"), false);
+            foodDefault |= GetOldOrDefaultConfigValue(new ConfigDefinition("1 - Player HUD (Requires Logout)", "useCustomFoodBar"), false);
+            customFoodBar = Config.Bind(sectionName, nameof(customFoodBar), foodDefault ? CustomBarState.on0Degrees : CustomBarState.off, $"Resizable, rotatable food bar. Requires {nameof(customHealthBar)}.");
+            customFoodBar.SettingChanged += (_, _) => CustomFoodBar_SettingChanged();
+            RemoveOldConfigValue<int>(new ConfigDefinition("1 - Player HUD", "foodBarRotation"));
+            RemoveOldConfigValue<int>(new ConfigDefinition("1 - Player HUD (Requires Logout)", "customFoodBarRotation"));
 
-            customHealthBarRotation = Config.Bind(sectionName, nameof(customHealthBarRotation), 90, "Rotate healthbar in degrees.");
+            var eitrDefault = GetOldOrDefaultConfigValue(new ConfigDefinition("1 - Player HUD", "useCustomEitrBar"), false);
+            customEitrBar = Config.Bind(sectionName, nameof(customEitrBar), eitrDefault ? CustomBarState.on0Degrees : CustomBarState.off, "Resizable, rotatable eitr bar. If you don't know what this is yet, just keep it disabled. This bar will always be visible and will not scale when you eat.");
+            customEitrBar.SettingChanged += (_, _) => CustomEitrBar_SettingChanged();
+            RemoveOldConfigValue<int>(new ConfigDefinition("1 - Player HUD", "foodBarRotation"));
+            RemoveOldConfigValue<int>(new ConfigDefinition("1 - Player HUD (Requires Logout)", "customFoodBarRotation"));
 
-            customStaminaBarRotation = Config.Bind(sectionName, nameof(customStaminaBarRotation), 90, "Rotate staminabar in degrees.");
+            customBarTextSize = Config.Bind(sectionName, nameof(customBarTextSize), 14, "Font size of the text on the custom bars.");
 
-            customSpoilerBarRotation = Config.Bind(sectionName, nameof(customSpoilerBarRotation), 90, "Rotate bar for the new spoiler resource in degrees.");
-
-            customFoodBarRotation = Config.Bind(sectionName, nameof(customFoodBarRotation), 180, "Rotate foodbar in degrees.");
-
-
+            //
             // Character Inventory
             sectionName = "2 - Character Inventory";
 
-            showDurabilityColor = Config.Bind(sectionName, nameof(showDurabilityColor), true, "Show colored durability bars for items.");
-
-            durabilityColorPalette = Config.Bind(sectionName, nameof(durabilityColorPalette), 0, "Change Durabilty bar colors. Options: 0 = Green, Yellow, Orange, Red, 1 = White, Light Yellow, Light Cyan, Blue.");
+            var wasColorOnDefault = GetOldOrDefaultConfigValue(new ConfigDefinition(sectionName, "showDurabilityColor"), true);
+            var colorDefault = GetOldOrDefaultConfigValue(new ConfigDefinition(sectionName, "durabilityColorPalette"), 0);
+            durabilityBarColorPalette = Config.Bind(sectionName, nameof(durabilityBarColorPalette), IntToDurabilityBarStyle(wasColorOnDefault, colorDefault), "Change durabilty bar colors. Options: 0 = Green, Yellow, Orange, Red, 1 = White, Light Yellow, Light Cyan, Blue.");
 
             showItemStars = Config.Bind(sectionName, nameof(showItemStars), true, "Show item quality as stars.");
 
             showCustomCharInfo = Config.Bind(sectionName, nameof(showCustomCharInfo), true, "Show Deaths, Builds, and Crafts stats on character selection screen. Also shows the Kills stat if something increases it.");
 
-            showCustomTooltips = Config.Bind(sectionName, nameof(showCustomTooltips), true, "Show more info on inventory item tooltips. Disable this is using Epic Loot.");
+            showCustomTooltips = Config.Bind(sectionName, nameof(showCustomTooltips), true, "Show more info on inventory item tooltips. Disable this if using Epic Loot.");
 
             showCombinedItemStats = Config.Bind(sectionName, nameof(showCombinedItemStats), true, "Show all item stats when mouse is hovered over armor amount.");
 
             iconScaleSize = Config.Bind(sectionName, nameof(iconScaleSize), 0.75f, "Scale item icon by this factor. Ex. 0.75 makes them 75% of original size.");
 
-
+            //
             // Skills UI
             sectionName = "3 - Character Skills";
 
@@ -166,19 +184,26 @@ namespace BetterUI
 
             skillUITextSize = Config.Bind(sectionName, nameof(skillUITextSize), 14, "Select text size on skills UI.");
 
-
+            //
             // Hover Text
             sectionName = "4 - Hover Text";
+            int timeLeftDefault;
 
-            timeLeftStyleFermenter = Config.Bind(sectionName, nameof(timeLeftStyleFermenter), 2, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left.");
+            timeLeftDefault = GetOldOrDefaultConfigValue(new ConfigDefinition(sectionName, "timeLeftStyleFermenter"), 2);
+            timeLeftHoverTextFermenter = Config.Bind(sectionName, nameof(timeLeftHoverTextFermenter), IntToTimeLeftStyle(timeLeftDefault), "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left.");
 
-            timeLeftStylePlant = Config.Bind(sectionName, nameof(timeLeftStylePlant), 2, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left.");
+            timeLeftDefault = GetOldOrDefaultConfigValue(new ConfigDefinition(sectionName, "timeLeftStylePlant"), 2);
+            timeLeftHoverTextPlant = Config.Bind(sectionName, nameof(timeLeftHoverTextPlant), IntToTimeLeftStyle(timeLeftDefault), "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left.");
 
-            timeLeftStyleCookingStation = Config.Bind(sectionName, nameof(timeLeftStyleCookingStation), 2, "Select duration display. 0 = Default, 1= % Done, 2 = min:sec left.");
+            timeLeftDefault = GetOldOrDefaultConfigValue(new ConfigDefinition(sectionName, "timeLeftStyleCookingStation"), 2);
+            timeLeftHoverTextCookingStation = Config.Bind(sectionName, nameof(timeLeftHoverTextCookingStation), IntToTimeLeftStyle(timeLeftDefault), "Select duration display. 0 = Default, 1= % Done, 2 = min:sec left.");
 
-            chestHasRoomStyle = Config.Bind(sectionName, nameof(chestHasRoomStyle), 2, "Select how chest emptyness is displayed. 0 = Default | 1 = % | 2 = items / max_room. | 3 = free slots.");
+            timeLeftHoverTextBeeHive = Config.Bind(sectionName, nameof(timeLeftHoverTextBeeHive), TimeLeftStyle.MinutesSecondsLeft, "Select duration display. 0 = Default, 1 = % Done, 2 = min:sec left.");
 
+            var chestStyleDefault = GetOldOrDefaultConfigValue(new ConfigDefinition(sectionName, "chestHasRoomStyle"), 2);
+            chestHasRoomHoverText = Config.Bind(sectionName, nameof(chestHasRoomHoverText), IntToChestHasRoomStyle(chestStyleDefault), "Select how chest emptiness is displayed. 0 = Default | 1 = % | 2 = items / max_room. | 3 = free slots.");
 
+            //
             // Character XP
             sectionName = "5 - Character XP";
 
@@ -190,12 +215,15 @@ namespace BetterUI
 
             extendedXPNotification = Config.Bind(sectionName, nameof(extendedXPNotification), true, "Extend notification with: (xp gained) [current/overall xp].");
 
+            skipRunningSkillNotifications = Config.Bind(sectionName, nameof(skipRunningSkillNotifications), true, "Whether to ignore xp gain notifications for the running skill.");
+
             // Character XP RESTART
             sectionName = "5 - Character XP (Requires Logout)";
 
-            showCharacterXpBar = Config.Bind(sectionName, nameof(showCharacterXpBar), true, "Show Character XP Bar on the bottom of the screen. Character XP must be enabled.");
+            var expBarDefault = GetOldOrDefaultConfigValue(new ConfigDefinition("5 - Character XP", nameof(showCharacterXpBar)), true);
+            showCharacterXpBar = Config.Bind(sectionName, nameof(showCharacterXpBar), expBarDefault, "Show Character XP Bar on the bottom of the screen. Character XP must be enabled.");
 
-
+            //
             // Enemy HUD
             sectionName = "6 - Enemy HUD";
 
@@ -205,7 +233,8 @@ namespace BetterUI
 
             showEnemyHPText = Config.Bind(sectionName, nameof(showEnemyHPText), true, "Show the text with HP amount on enemies health bar.");
 
-            enemyLvlStyle = Config.Bind(sectionName, nameof(enemyLvlStyle), 0, "Choose how enemy lvl is shown. 0 = Default (stars) | 1 = Prefix before name (Lv. 1) | 2 = Both.");
+            var enemyLevelStyleDefault = GetOldOrDefaultConfigValue(new ConfigDefinition(sectionName, "enemyLvlStyle"), 0);
+            enemyLevelStyle = Config.Bind(sectionName, nameof(enemyLevelStyle), IntToEnemyLevelStyle(enemyLevelStyleDefault), "Choose how enemy lvl is shown. 0 = Default (stars) | 1 = Prefix before name (Lv. 1) | 2 = Both.");
 
             enemyNameTextSize = Config.Bind(sectionName, nameof(enemyNameTextSize), 14, "Font size of the name on the enemy.");
 
@@ -224,33 +253,229 @@ namespace BetterUI
 
             maxShowDistance = Config.Bind(sectionName, nameof(maxShowDistance), 1f, "How far you will see enemy HP Bar. This is an multiplier, 1 = game default, 2 = 2x default.");
 
-
+            //
             // Map
             sectionName = "7 - Map";
 
             mapPinScaleSize = Config.Bind(sectionName, nameof(mapPinScaleSize), 1f, "Scale map pins by this factor. Ex. 1.5 makes the 150% of original size.");
 
-
+            //
             // Debug
             sectionName = "8 - Debug";
 
             isDebug = Config.Bind(sectionName, nameof(isDebug), false, "Enable debug logging.");
 
-
+            //
             // xDataUI
             sectionName = "9 - xDataUI";
             uiData = Config.Bind(sectionName, nameof(uiData), "none", "This is your customized UI info. Edit to none, if having issues or wanting to reset positions.");
+
+            if (isDebug.Value)
+            {
+                PrintOrphanedEntries();
+            }
         }
+
+        private DurabilityBarStyle IntToDurabilityBarStyle(bool wasColorPaletteOn, int selectedColorPalette)
+        {
+            if (!wasColorPaletteOn)
+            {
+                return DurabilityBarStyle.Disabled;
+            }
+            else
+            {
+                return selectedColorPalette == 0 ? DurabilityBarStyle.GreenYellowOrangeRed : DurabilityBarStyle.WhiteLightYellowLightCyanBlue;
+            }
+        }
+
+        private ChestHasRoomStyle IntToChestHasRoomStyle(int value)
+        {
+            if (value > 0 && value <= 3)
+            {
+                return (ChestHasRoomStyle)value;
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
+        private TimeLeftStyle IntToTimeLeftStyle(int value)
+        {
+            switch (value)
+            {
+                case 1:
+                    return TimeLeftStyle.PercentageDone;
+
+                case 2:
+                    return TimeLeftStyle.MinutesSecondsLeft;
+
+                default:
+                    return TimeLeftStyle.Disabled;
+            }
+        }
+
+        private EnemyLevelStyle IntToEnemyLevelStyle(int value)
+        {
+            switch (value)
+            {
+                case 1:
+                    return EnemyLevelStyle.PrefixLevelNumber;
+
+                case 2:
+                    return EnemyLevelStyle.Both;
+
+                default:
+                    return EnemyLevelStyle.DefaultStars;
+            }
+        }
+
+        private void CustomFoodBar_SettingChanged()
+        {
+            Patches.CustomBars.FoodBar.UpdateRotation();
+        }
+
+        private void CustomStaminaBar_SettingChanged()
+        {
+            Patches.CustomBars.StaminaBar.UpdateRotation();
+        }
+
+        private void CustomHealthBar_SettingChanged()
+        {
+            Patches.CustomBars.HealthBar.UpdateRotation();
+        }
+
+        private void CustomEitrBar_SettingChanged()
+        {
+            Patches.CustomBars.EitrBar.UpdateRotation();
+        }
+
         public void Start()
         {
             harmony.PatchAll(assembly);
         }
 
-        /*
-        public void OnDestroy()
+        public void RemoveOldConfigValue<T>(ConfigDefinition configDefinition)
         {
-          harmony?.UpatchSelf();
+            GetOldOrDefaultConfigValue(configDefinition, default(T));
         }
-        */
+
+        /// <summary>
+        /// Rebinds the old orphan config definition and then immediately removes it again, and returns its last value
+        /// This properly deletes an old config value
+        /// </summary>
+        public T GetOldOrDefaultConfigValue<T>(ConfigDefinition configDefinition, T defaultValue)
+        {
+            T oldOrDefaultValue = Config.Bind(configDefinition, defaultValue).Value;
+            Config.Remove(configDefinition);
+
+            if (Config.SaveOnConfigSet)
+            {
+                Config.Save();
+            }
+
+            return oldOrDefaultValue;
+        }
+
+        public bool TryGetOldConfigValue<T>(ConfigDefinition configDefinition, ref T oldValue, bool removeIfFound = true)
+        {
+            if (!TomlTypeConverter.CanConvert(typeof(T)))
+            {
+                throw new ArgumentException(string.Format("Type {0} is not supported by the config system. Supported types: {1}", typeof(T), string.Join(", ", (from x in TomlTypeConverter.GetSupportedTypes() select x.Name).ToArray())));
+            }
+
+            try
+            {
+                var iolock = AccessTools.FieldRefAccess<ConfigFile, object>("_ioLock").Invoke(Config);
+                var orphanedEntries = (Dictionary<ConfigDefinition, string>)AccessTools.PropertyGetter(typeof(ConfigFile), "OrphanedEntries").Invoke(Config, new object[0]);
+
+                lock (iolock)
+                {
+                    if (orphanedEntries.TryGetValue(configDefinition, out string oldValueString))
+                    {
+                        oldValue = (T)TomlTypeConverter.ConvertToValue(oldValueString, typeof(T));
+
+                        if (removeIfFound)
+                        {
+                            orphanedEntries.Remove(configDefinition);
+                        }
+
+                        return true;
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"Error getting orphaned entry: {e.StackTrace}");
+            }
+
+            return false;
+        }
+
+        public void PrintOrphanedEntries()
+        {
+            try
+            {
+                var iolock = AccessTools.FieldRefAccess<ConfigFile, object>("_ioLock").Invoke(Config);
+                var orphanedEntries = (Dictionary<ConfigDefinition, string>)AccessTools.PropertyGetter(typeof(ConfigFile), "OrphanedEntries").Invoke(Config, new object[0]);
+
+                if (orphanedEntries.Count == 0)
+                {
+                    return;
+                }
+
+                lock (iolock)
+                {
+                    Debug.Log("printing orphaned config values");
+
+                    foreach (var item in orphanedEntries)
+                    {
+                        Debug.Log($"{item.Key.Section},{item.Key.Key}: {item.Value}");
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"Error logging orphaned entries: {e.StackTrace}");
+            }
+        }
+
+        public enum CustomBarState
+        {
+            off = -1,
+            on0Degrees = 0,
+            on90Degrees = 90,
+            on180Degrees = 180,
+            on270Degrees = 270
+        }
+
+        public enum DurabilityBarStyle
+        {
+            Disabled = -1,
+            GreenYellowOrangeRed = 0,
+            WhiteLightYellowLightCyanBlue = 1
+        }
+
+        public enum TimeLeftStyle
+        {
+            Disabled = 0,
+            PercentageDone = 1,
+            MinutesSecondsLeft = 2
+        }
+
+        public enum ChestHasRoomStyle
+        {
+            Disabled = 0,
+            Percentage = 1,
+            ItemsSlashMaxRoom = 2,
+            AmountOfFreeSlots = 3
+        }
+
+        public enum EnemyLevelStyle
+        {
+            DefaultStars = 0,
+            PrefixLevelNumber = 1,
+            Both = 2
+        }
     }
 }

--- a/BetterUI/Main.cs
+++ b/BetterUI/Main.cs
@@ -138,7 +138,7 @@ namespace BetterUI
 
             customSpoilerBarRotation = Config.Bind(sectionName, nameof(customSpoilerBarRotation), 90, "Rotate bar for the new spoiler resource in degrees.");
 
-            customFoodBarRotation = Config.Bind(sectionName, nameof(customFoodBarRotation), 90, "Rotate foodbar in degrees.");
+            customFoodBarRotation = Config.Bind(sectionName, nameof(customFoodBarRotation), 180, "Rotate foodbar in degrees.");
 
 
             // Character Inventory

--- a/BetterUI/Patches/CustomBars.cs
+++ b/BetterUI/Patches/CustomBars.cs
@@ -435,6 +435,7 @@ namespace BetterUI.Patches
                                 }
 
                                 foodTime.gameObject.SetActive(true);
+                                foodTime.fontSize = customFoodBarTextSize.Value;
 
                                 if (food.m_time >= 60f)
                                 {

--- a/BetterUI/Patches/CustomBars.cs
+++ b/BetterUI/Patches/CustomBars.cs
@@ -2,10 +2,11 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.UI;
+using static BetterUI.Main;
 
 namespace BetterUI.Patches
 {
-    internal class CustomElements
+    internal class CustomBars
     {
         public static class BarHelper
         {
@@ -14,7 +15,7 @@ namespace BetterUI.Patches
             public const float scalingFactor = 0.6f;
             public const int padding = 0;
 
-            public static void BaseCreate(string objectName, string origBarName, int configRotation, ref RectTransform root, ref GuiBar slowBar, ref GuiBar fastBar, ref Text barText)
+            public static void BaseCreate(string objectName, string origBarName, ref RectTransform root, ref GuiBar slowBar, ref GuiBar fastBar, ref Text barText)
             {
                 // we've obviously already done this before if it's not null
                 if (root != null)
@@ -28,26 +29,29 @@ namespace BetterUI.Patches
                 root = UnityEngine.Object.Instantiate(Hud.instance.m_healthBarRoot, Hud.instance.transform.Find("hudroot"));
                 root.gameObject.name = objectName;
 
-                int rot = 90 - (configRotation / 90 % 4 * 90);
-                root.localEulerAngles = new Vector3(0, 0, rot);
-
                 fastBar = root.Find("fast").GetComponent<GuiBar>();
                 slowBar = root.Find("slow").GetComponent<GuiBar>();
 
-                root.Find("fast").Find("bar").Find("HealthText").gameObject.SetActive(false);
-
-                barText = UnityEngine.Object.Instantiate(root.Find("fast").Find("bar").Find("HealthText").GetComponent<Text>(), root);
-                barText.GetComponent<RectTransform>().localEulerAngles = new Vector3(0, 0, -rot);
-
-                // Resize to a more "slim" rectangle - authors preference
-                barText.GetComponent<RectTransform>().localScale = new Vector3(scalingFactor, scalingFactor, 1f);
+                var fastBarHealthText = fastBar.transform.Find("bar").Find("HealthText");
+                fastBarHealthText.gameObject.SetActive(false);
+                barText = UnityEngine.Object.Instantiate(fastBarHealthText.GetComponent<Text>(), root);
+                barText.gameObject.AddComponent<TextScaler>();
                 barText.gameObject.SetActive(true);
 
-                root.Find("border").GetComponent<RectTransform>().localScale = new Vector3(1f, scalingFactor, 1f);
-                root.Find("bkg").GetComponent<RectTransform>().localScale = new Vector3(1f, scalingFactor, 1f);
+                // Resize to a more "slim" rectangle - authors preference
+                root.Find("border").localScale = new Vector3(1f, scalingFactor, 1f);
+                root.Find("bkg").localScale = new Vector3(1f, scalingFactor, 1f);
 
-                fastBar.GetComponent<RectTransform>().localScale = new Vector3(1f, scalingFactor, 1f);
-                slowBar.GetComponent<RectTransform>().localScale = new Vector3(1f, scalingFactor, 1f);
+                fastBar.transform.localScale = new Vector3(1f, scalingFactor, 1f);
+                slowBar.transform.localScale = new Vector3(1f, scalingFactor, 1f);
+            }
+
+            public static void UpdateRotation(int configRotation, ref RectTransform root, ref Text barText)
+            {
+                //configRotation = (configRotation + 180) % 360;
+
+                root.localEulerAngles = new Vector3(0, 0, configRotation);
+                barText.transform.localEulerAngles = new Vector3(0, 0, -configRotation);
             }
 
             public static void HealthStyleUpdate(float max, float current, ref GuiBar slowBar, ref GuiBar fastBar, ref Text barText)
@@ -57,6 +61,7 @@ namespace BetterUI.Patches
                 slowBar.SetMaxValue(max);
                 slowBar.SetValue(current);
 
+                barText.fontSize = Main.customBarTextSize.Value;
                 barText.text = $"{Mathf.CeilToInt(current)}/{Mathf.CeilToInt(max)}";
             }
 
@@ -65,23 +70,77 @@ namespace BetterUI.Patches
                 fastBar.SetValue(current / max);
                 slowBar.SetValue(current / max);
 
+                barText.fontSize = Main.customBarTextSize.Value;
                 barText.text = $"{Mathf.CeilToInt(current)}/{Mathf.CeilToInt(max)}";
+            }
+
+            public static CustomBarState IncrementRotation(CustomBarState state)
+            {
+                switch (state)
+                {
+                    case CustomBarState.on0Degrees:
+                        return CustomBarState.on90Degrees;
+
+                    case CustomBarState.on90Degrees:
+                        return CustomBarState.on180Degrees;
+
+                    case CustomBarState.on180Degrees:
+                        return CustomBarState.on270Degrees;
+
+                    case CustomBarState.on270Degrees:
+                        return CustomBarState.on0Degrees;
+
+                    default:
+                        return state;
+                }
+            }
+
+            public static CustomBarState DecrementRotation(CustomBarState state)
+            {
+                switch (state)
+                {
+                    case CustomBarState.on0Degrees:
+                        return CustomBarState.on270Degrees;
+
+                    case CustomBarState.on90Degrees:
+                        return CustomBarState.on0Degrees;
+
+                    case CustomBarState.on180Degrees:
+                        return CustomBarState.on0Degrees;
+
+                    case CustomBarState.on270Degrees:
+                        return CustomBarState.on180Degrees;
+
+                    default:
+                        return state;
+                }
             }
         }
 
         public static class HealthBar
         {
-            public static readonly string objectName = "BetterUI_HPBar";
+            public const string objectName = "BetterUI_HPBar";
             internal static RectTransform root;
             internal static GuiBar slowBar;
             internal static GuiBar fastBar;
             internal static Text barText;
 
+            public static void UpdateRotation()
+            {
+                if (root == null || Main.customHealthBar.Value == Main.CustomBarState.off)
+                {
+                    return;
+                }
+
+                BarHelper.UpdateRotation((int)Main.customHealthBar.Value, ref root, ref barText);
+            }
+
             public static void Create()
             {
                 try
                 {
-                    BarHelper.BaseCreate(objectName, "healthpanel", Main.customHealthBarRotation.Value, ref root, ref slowBar, ref fastBar, ref barText);
+                    BarHelper.BaseCreate(objectName, "healthpanel", ref root, ref slowBar, ref fastBar, ref barText);
+                    UpdateRotation();
 
                     // go to a good default position that can get overriden by the editing feature if needed
                     // go up and left
@@ -89,7 +148,7 @@ namespace BetterUI.Patches
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"{nameof(HealthBar)}.{nameof(Create)}() {e.Message}");
+                    Debug.LogError($"{nameof(HealthBar)}.{nameof(Create)}() {e.Message} {e.StackTrace}");
                 }
             }
 
@@ -104,24 +163,35 @@ namespace BetterUI.Patches
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"{nameof(HealthBar)}.{nameof(Update)}() {e.Message}");
+                    Debug.LogError($"{nameof(HealthBar)}.{nameof(Update)}() {e.Message} {e.StackTrace}");
                 }
             }
         }
 
         public static class StaminaBar
         {
-            public static readonly string objectName = "BetterUI_StaminaBar";
+            public const string objectName = "BetterUI_StaminaBar";
             internal static RectTransform root;
             internal static GuiBar slowBar;
             internal static GuiBar fastBar;
             internal static Text barText;
 
+            public static void UpdateRotation()
+            {
+                if (root == null || Main.customStaminaBar.Value == Main.CustomBarState.off)
+                {
+                    return;
+                }
+
+                BarHelper.UpdateRotation((int)Main.customStaminaBar.Value, ref root, ref barText);
+            }
+
             public static void Create()
             {
                 try
                 {
-                    BarHelper.BaseCreate(objectName, "staminapanel", Main.customStaminaBarRotation.Value, ref root, ref slowBar, ref fastBar, ref barText);
+                    BarHelper.BaseCreate(objectName, "staminapanel", ref root, ref slowBar, ref fastBar, ref barText);
+                    UpdateRotation();
 
                     fastBar.m_originalColor = Hud.instance.m_staminaBar2Fast.m_bar.GetComponent<Image>().color;
                     slowBar.m_originalColor = Hud.instance.m_staminaBar2Slow.m_bar.GetComponent<Image>().color;
@@ -136,7 +206,7 @@ namespace BetterUI.Patches
                     // go left
                     root.position -= new Vector3(BarHelper.StepSize / 4, 0);
 
-                    if (Main.useCustomHealthBar.Value)
+                    if (Main.customHealthBar.Value != Main.CustomBarState.off)
                     {
                         // hold positon
                         root.position -= new Vector3(0, BarHelper.padding);
@@ -149,7 +219,7 @@ namespace BetterUI.Patches
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"{nameof(StaminaBar)}.{nameof(Create)}() {e.Message}");
+                    Debug.LogError($"{nameof(StaminaBar)}.{nameof(Create)}() {e.Message} {e.StackTrace}");
                 }
             }
 
@@ -164,24 +234,35 @@ namespace BetterUI.Patches
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"{nameof(StaminaBar)}.{nameof(Update)}() {e.Message}");
+                    Debug.LogError($"{nameof(StaminaBar)}.{nameof(Update)}() {e.Message} {e.StackTrace}");
                 }
             }
         }
 
         public static class EitrBar
         {
-            public static readonly string objectName = "BetterUI_EitrBar";
+            public const string objectName = "BetterUI_EitrBar";
             internal static RectTransform root;
             internal static GuiBar slowBar;
             internal static GuiBar fastBar;
             internal static Text barText;
 
+            public static void UpdateRotation()
+            {
+                if (root == null || Main.customEitrBar.Value == Main.CustomBarState.off)
+                {
+                    return;
+                }
+
+                BarHelper.UpdateRotation((int)Main.customEitrBar.Value, ref root, ref barText);
+            }
+
             public static void Create()
             {
                 try
                 {
-                    BarHelper.BaseCreate("BetterUI_EitrBar", "eitrpanel", Main.customSpoilerBarRotation.Value, ref root, ref slowBar, ref fastBar, ref barText);
+                    BarHelper.BaseCreate("BetterUI_EitrBar", "eitrpanel", ref root, ref slowBar, ref fastBar, ref barText);
+                    UpdateRotation();
 
                     fastBar.m_originalColor = Hud.instance.m_eitrBarFast.m_bar.GetComponent<Image>().color;
                     slowBar.m_originalColor = Hud.instance.m_eitrBarSlow.m_bar.GetComponent<Image>().color;
@@ -196,12 +277,12 @@ namespace BetterUI.Patches
                     // go left
                     root.position -= new Vector3(BarHelper.StepSize / 4, 0);
 
-                    if (Main.useCustomHealthBar.Value)
+                    if (Main.customHealthBar.Value != Main.CustomBarState.off)
                     {
                         // hold position
                         root.position -= new Vector3(0, BarHelper.padding);
 
-                        if (Main.useCustomStaminaBar.Value)
+                        if (Main.customStaminaBar.Value != Main.CustomBarState.off)
                         {
                             // go down
                             root.position -= new Vector3(0, BarHelper.StepSize / 4 + BarHelper.padding);
@@ -215,7 +296,7 @@ namespace BetterUI.Patches
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"{nameof(EitrBar)}.{nameof(Create)}() {e.Message}");
+                    Debug.LogError($"{nameof(EitrBar)}.{nameof(Create)}() {e.Message} {e.StackTrace}");
                 }
             }
 
@@ -230,19 +311,38 @@ namespace BetterUI.Patches
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"{nameof(EitrBar)}.{nameof(Update)}() {e.Message}");
+                    Debug.LogError($"{nameof(EitrBar)}.{nameof(Update)}() {e.Message} {e.StackTrace}");
                 }
             }
         }
 
         public static class FoodBar
         {
-            public static readonly string objectName = "BetterUI_FoodBar";
+            public const string objectName = "BetterUI_FoodBar";
             private static RectTransform foodPanel;
             private static RectTransform foodBarRoot;
-            public static RectTransform food0;
-            public static RectTransform food1;
-            public static RectTransform food2;
+            private static RectTransform foodBaseBar;
+
+            private static Image[] foodBars;
+            private static Image[] foodIcons;
+            private static Text[] foodTimes;
+            private static Transform[] foodTransforms;
+
+            public static void UpdateRotation()
+            {
+                if (foodPanel == null || Main.customFoodBar.Value == Main.CustomBarState.off)
+                {
+                    return;
+                }
+
+                int rot = ((int)Main.customFoodBar.Value + 270) % 360;
+                foodPanel.localEulerAngles = new Vector3(0, 0, rot);
+
+                foreach (var item in foodTransforms)
+                {
+                    item.localEulerAngles = new Vector3(0, 0, -rot);
+                }
+            }
 
             public static void Create()
             {
@@ -255,26 +355,33 @@ namespace BetterUI.Patches
                     }
 
                     // original food panel gets hidden by hiding the original health bar, so if the user doesn't use that feature, then they would have two food bars
-                    if (!Main.useCustomHealthBar.Value)
+                    if (Main.customHealthBar.Value == Main.CustomBarState.off)
                     {
-                        Debug.LogWarning($"{nameof(Main.useCustomFoodBar)} requires {nameof(Main.useCustomHealthBar)}. No custom food bar will be created. Activate {nameof(Main.useCustomHealthBar)} and log out and back in to use {nameof(Main.useCustomFoodBar)}.");
+                        Debug.LogWarning($"{nameof(Main.customFoodBar)} requires {nameof(Main.customHealthBar)}. No custom food bar will be created. Activate {nameof(Main.customHealthBar)} and log out and back in to use {nameof(Main.customFoodBar)}.");
                         return;
                     }
 
                     foodPanel = UnityEngine.Object.Instantiate(Hud.instance.m_healthPanel, Hud.instance.transform.Find("hudroot"));
                     foodPanel.gameObject.name = objectName;
                     foodPanel.gameObject.SetActive(true);
-                    int rot = 90 - (Main.customFoodBarRotation.Value / 90 % 4 * 90);
-                    foodPanel.localEulerAngles = new Vector3(0, 0, rot);
 
                     foodBarRoot = foodPanel.Find("Food").GetComponent<RectTransform>();
-                    food0 = foodPanel.Find("food0").GetComponent<RectTransform>();
-                    food1 = foodPanel.Find("food1").GetComponent<RectTransform>();
-                    food2 = foodPanel.Find("food2").GetComponent<RectTransform>();
+                    foodBaseBar = foodBarRoot.Find("baseBar").GetComponent<RectTransform>();
 
-                    food0.localEulerAngles = new Vector3(0, 0, -rot);
-                    food1.localEulerAngles = new Vector3(0, 0, -rot);
-                    food2.localEulerAngles = new Vector3(0, 0, -rot);
+                    foodBars = new Image[Hud.instance.m_foodBars.Length];
+                    foodIcons = new Image[Hud.instance.m_foodIcons.Length];
+                    foodTimes = new Text[Hud.instance.m_foodTime.Length];
+                    foodTransforms = new Transform[Hud.instance.m_foodTime.Length];
+
+                    for (int i = 0; i < Hud.instance.m_foodBars.Length; i++)
+                    {
+                        foodBars[i] = foodBarRoot.Find(Hud.instance.m_foodBars[i].name).GetComponent<Image>();
+                        foodTransforms[i] = foodPanel.Find($"food{i}");
+                        foodIcons[i] = foodTransforms[i].Find($"foodicon{i}").GetComponent<Image>();
+                        foodTimes[i] = foodTransforms[i].Find($"time").GetComponent<Text>();
+                    }
+
+                    UpdateRotation();
 
                     // Stuff to remove / hide
                     foodPanel.Find("Health").gameObject.SetActive(false);
@@ -289,7 +396,7 @@ namespace BetterUI.Patches
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"{nameof(FoodBar)}.{nameof(Create)}() {e.Message}");
+                    Debug.LogError($"{nameof(FoodBar)}.{nameof(Create)}() {e.Message} {e.StackTrace}");
                 }
             }
 
@@ -302,49 +409,49 @@ namespace BetterUI.Patches
                     {
                         List<Player.Food> foods = player.GetFoods();
                         float baseHP = player.GetBaseFoodHP() / 25f * 32f;
-                        foodBarRoot.Find("baseBar").GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, baseHP);
+                        foodBaseBar.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, baseHP);
                         float barLength = baseHP;
 
                         for (int i = 0; i < Hud.instance.m_foodBars.Length; i++)
                         {
-                            Image image = foodBarRoot.Find(Hud.instance.m_foodBars[i].name).GetComponent<Image>();
-                            Image image2 = foodPanel.Find($"food{i}").Find($"foodicon{i}").GetComponent<Image>();
-                            Text text = foodPanel.Find($"food{i}").Find($"time").GetComponent<Text>();
+                            Image foodBar = foodBars[i];
+                            Image foodIcon = foodIcons[i];
+                            Text foodTime = foodTimes[i];
 
                             if (i < foods.Count)
                             {
-                                image.gameObject.SetActive(true);
+                                foodBar.gameObject.SetActive(true);
                                 Player.Food food = foods[i];
-                                image2.gameObject.SetActive(true);
-                                image2.sprite = food.m_item.GetIcon();
+                                foodIcon.gameObject.SetActive(true);
+                                foodIcon.sprite = food.m_item.GetIcon();
 
                                 if (food.CanEatAgain())
                                 {
-                                    image2.color = new Color(1f, 1f, 1f, 0.7f + Mathf.Sin(Time.time * 5f) * 0.3f);
+                                    foodIcon.color = new Color(1f, 1f, 1f, 0.7f + Mathf.Sin(Time.time * 5f) * 0.3f);
                                 }
                                 else
                                 {
-                                    image2.color = Color.white;
+                                    foodIcon.color = Color.white;
                                 }
 
-                                text.gameObject.SetActive(true);
+                                foodTime.gameObject.SetActive(true);
 
                                 if (food.m_time >= 60f)
                                 {
-                                    text.text = Mathf.CeilToInt(food.m_time / 60f) + "m";
-                                    text.color = Color.white;
+                                    foodTime.text = Mathf.CeilToInt(food.m_time / 60f) + "m";
+                                    foodTime.color = Color.white;
                                 }
                                 else
                                 {
-                                    text.text = Mathf.FloorToInt(food.m_time) + "s";
-                                    text.color = new Color(1f, 1f, 1f, 0.4f + Mathf.Sin(Time.time * 10f) * 0.6f);
+                                    foodTime.text = Mathf.FloorToInt(food.m_time) + "s";
+                                    foodTime.color = new Color(1f, 1f, 1f, 0.4f + Mathf.Sin(Time.time * 10f) * 0.6f);
                                 }
                             }
                             else
                             {
-                                image.gameObject.SetActive(false);
-                                image2.gameObject.SetActive(false);
-                                text.gameObject.SetActive(false);
+                                foodBar.gameObject.SetActive(false);
+                                foodIcon.gameObject.SetActive(false);
+                                foodTime.gameObject.SetActive(false);
                             }
                         }
 
@@ -354,7 +461,7 @@ namespace BetterUI.Patches
                 }
                 catch (Exception e)
                 {
-                    Debug.LogError($"{nameof(FoodBar)}.{nameof(Update)}() {e.Message}");
+                    Debug.LogError($"{nameof(FoodBar)}.{nameof(Update)}() {e.Message} {e.StackTrace}");
                 }
             }
         }

--- a/BetterUI/Patches/CustomElements.cs
+++ b/BetterUI/Patches/CustomElements.cs
@@ -5,224 +5,358 @@ using UnityEngine.UI;
 
 namespace BetterUI.Patches
 {
-  static class CustomElements
-  {
-    public static class HealthBar
+    internal class CustomElements
     {
-      public static readonly string objectName = "BetterUI_HPBar";
-      private static RectTransform healthBarRoot;
-      private static GuiBar healthBarSlow;
-      private static GuiBar healthBarFast;
-      private static Text healthText;
-
-      public static void Create()
-      {
-        try
+        public static class BarHelper
         {
-          // Hide original healthBar
-          Hud.instance.transform.Find("hudroot").Find("healthpanel").gameObject.SetActive(false);
+            public static float StepSize => Hud.instance.m_healthPanel.sizeDelta.x;
 
-          healthBarRoot = UnityEngine.Object.Instantiate(Hud.instance.m_healthBarRoot, Hud.instance.transform.Find("hudroot"));
-          healthBarRoot.gameObject.name = objectName;
+            public const float scalingFactor = 0.6f;
+            public const int padding = 0;
 
-          // Rotate this to 90
-          int rot = 90 - (Main.healthBarRotation.Value / 90 % 4 * 90);
-          healthBarRoot.localEulerAngles = new Vector3(0, 0, rot);
-
-          healthBarFast = healthBarRoot.Find("fast").GetComponent<GuiBar>();
-          healthBarSlow = healthBarRoot.Find("slow").GetComponent<GuiBar>();
-
-          healthBarRoot.Find("fast").Find("bar").Find("HealthText").gameObject.SetActive(false);
-
-          healthText = UnityEngine.Object.Instantiate(healthBarRoot.Find("fast").Find("bar").Find("HealthText").GetComponent<Text>(), healthBarRoot);
-          healthText.GetComponent<RectTransform>().localEulerAngles = new Vector3(0, 0, -rot);
-          healthText.GetComponent<RectTransform>().localScale = new Vector3(0.65f, 0.65f, 1f);
-          healthText.gameObject.SetActive(true);
-
-          // Resize to a more "slim" rectangle - authors preference
-          healthBarRoot.Find("border").GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-          healthBarRoot.Find("bkg").GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-          healthBarFast.GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-          healthBarSlow.GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-
-        }
-        catch (Exception e)
-        {
-          Debug.LogError($"HealthBar.Create() {e.Message}");
-        }
-      }
-
-      public static void Update(float max, float hp)
-      {
-        try
-        {
-          healthBarFast.SetMaxValue(max);
-          healthBarFast.SetValue(hp);
-          healthBarSlow.SetMaxValue(max);
-          healthBarSlow.SetValue(hp);
-          healthText.text = $"{Mathf.CeilToInt(hp)}/{Mathf.CeilToInt(max)}";
-        }
-        catch (Exception e)
-        {
-          Debug.LogError($"HealthBar.Update() {e.Message}");
-        }
-      }
-    }
-
-    public static class StaminaBar
-    {
-      public static readonly string objectName = "BetterUI_StaminaBar";
-      private static RectTransform staminaBarRoot;
-      private static GuiBar staminaBarSlow;
-      private static GuiBar staminaBarFast;
-      private static Text staminaText;
-
-      public static void Create()
-      {
-        try
-        {
-          // Hide original staminaBar
-          Hud.instance.transform.Find("hudroot").Find("staminapanel").gameObject.SetActive(false);
-
-          staminaBarRoot = UnityEngine.Object.Instantiate(Hud.instance.m_healthBarRoot, Hud.instance.transform.Find("hudroot"));
-          staminaBarRoot.gameObject.name = objectName;
-
-          int rot = 90 - (Main.staminaBarRotation.Value / 90 % 4 * 90);
-          staminaBarRoot.localEulerAngles = new Vector3(0, 0, rot);
-
-          staminaBarFast = staminaBarRoot.Find("fast").GetComponent<GuiBar>();
-          staminaBarSlow = staminaBarRoot.Find("slow").GetComponent<GuiBar>();
-
-          staminaBarRoot.Find("fast").Find("bar").Find("HealthText").gameObject.SetActive(false);
-
-          staminaText = UnityEngine.Object.Instantiate(staminaBarRoot.Find("fast").Find("bar").Find("HealthText").GetComponent<Text>(), staminaBarRoot);
-          staminaText.GetComponent<RectTransform>().localEulerAngles = new Vector3(0, 0, -rot);
-          staminaText.GetComponent<RectTransform>().localScale = new Vector3(0.65f, 0.65f, 1f);
-          staminaText.gameObject.SetActive(true);
-
-          staminaBarRoot.Find("border").GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-          staminaBarRoot.Find("bkg").GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-          staminaBarFast.GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-          staminaBarSlow.GetComponent<RectTransform>().localScale = new Vector3(1f, 0.65f, 1f);
-
-          staminaBarFast.m_originalColor = Hud.instance.m_staminaBar2Fast.m_bar.GetComponent<Image>().color;
-          staminaBarFast.ResetColor();
-          staminaBarSlow.m_originalColor = Hud.instance.m_staminaBar2Slow.m_bar.GetComponent<Image>().color;
-          staminaBarSlow.ResetColor();
-
-          staminaBarFast.m_smoothDrain = Hud.instance.m_staminaBar2Fast.m_smoothDrain;
-          staminaBarFast.m_changeDelay = Hud.instance.m_staminaBar2Fast.m_changeDelay;
-          staminaBarFast.m_smoothSpeed = Hud.instance.m_staminaBar2Fast.m_smoothSpeed;
-        }
-        catch (Exception e)
-        {
-          Debug.LogError($"StaminaBar.Create() {e.Message}");
-        }
-      }
-
-      public static void Update(float max, float stamina)
-      {
-        try
-        {
-          staminaBarFast.SetValue(stamina / max);
-          staminaBarSlow.SetValue(stamina / max);
-          staminaText.text = $"{Mathf.CeilToInt(stamina)}/{Mathf.CeilToInt(max)}";
-        }
-        catch (Exception e)
-        {
-          Debug.LogError($"StaminaBar.Update() {e.Message}");
-        }
-      }
-    }
-
-    public static class FoodBar
-    {
-      public static readonly string objectName = "BetterUI_FoodBar";
-      private static RectTransform foodPanel;
-      private static RectTransform foodBarRoot;
-      public static RectTransform food0;
-      public static RectTransform food1;
-      public static RectTransform food2;
-
-      public static void Create()
-      {
-        foodPanel = UnityEngine.Object.Instantiate(Hud.instance.m_healthPanel, Hud.instance.transform.Find("hudroot"));
-        foodPanel.gameObject.name = objectName;
-        foodPanel.gameObject.SetActive(true);
-        int rot = 90 - (Main.foodBarRotation.Value / 90 % 4 * 90);
-        foodPanel.localEulerAngles = new Vector3(0, 0, rot);
-
-        foodBarRoot = foodPanel.Find("Food").GetComponent<RectTransform>();
-        food0 = foodPanel.Find("food0").GetComponent<RectTransform>();
-        food1 = foodPanel.Find("food1").GetComponent<RectTransform>();
-        food2 = foodPanel.Find("food2").GetComponent<RectTransform>();
-
-        food0.localEulerAngles = new Vector3(0, 0, -rot);
-        food1.localEulerAngles = new Vector3(0, 0, -rot);
-        food2.localEulerAngles = new Vector3(0, 0, -rot);
-
-        // Stuff to remove / hide
-        foodPanel.Find("Health").gameObject.SetActive(false);
-        foodPanel.Find("darken").gameObject.SetActive(false);
-        foodPanel.Find("healthicon").gameObject.SetActive(false);
-        foodPanel.Find("foodicon").gameObject.SetActive(false);
-      }
-
-      public static void Update(Player player)
-      {
-        List<Player.Food> foods = player.GetFoods();
-        float baseHP = player.GetBaseFoodHP() / 25f * 32f;
-        foodBarRoot.Find("baseBar").GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, baseHP);
-        float barLength = baseHP;
-        for (int i = 0; i < Hud.instance.m_foodBars.Length; i++)
-        {
-          Image image = Hud.instance.m_foodBars[i]; // foodBarRoot (bar1, bar2, bar3, baseBar?)
-          Image icon = Hud.instance.m_foodIcons[i]; // food0 -> foodicon0
-
-          if (i < foods.Count)
-          {
-            Player.Food food = foods[i];
-            Image tmpImage = foodBarRoot.Find(image.name).GetComponent<Image>();
-            Image tmpIcon = foodPanel.Find($"food{i}").Find($"foodicon{i}").GetComponent<Image>();
-            Text tmpText = foodPanel.Find($"food{i}").Find($"time").GetComponent<Text>();
-            tmpImage.gameObject.SetActive(true);
-            tmpImage.color = image.color;
-            tmpImage.rectTransform.anchoredPosition = image.rectTransform.anchoredPosition;
-            tmpImage.rectTransform.sizeDelta = image.rectTransform.sizeDelta;
-            float barWidth = food.m_health / 25f * 32f;
-            tmpImage.rectTransform.anchoredPosition = new Vector2(barLength, 0f);
-            tmpImage.rectTransform.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, Mathf.Ceil(barWidth));
-            barLength += barWidth;
-
-            tmpIcon.sprite = icon.sprite;
-            tmpIcon.gameObject.SetActive(true);
-            tmpIcon.color = icon.color;
-
-            tmpText.gameObject.SetActive(true);
-            if (food.m_time >= 60f)
+            public static void BaseCreate(string objectName, string origBarName, int configRotation, ref RectTransform root, ref GuiBar slowBar, ref GuiBar fastBar, ref Text barText)
             {
-              tmpText.text = Mathf.CeilToInt(food.m_time / 60f) + "m";
-              tmpText.color = Color.white;
+                // we've obviously already done this before if it's not null
+                if (root != null)
+                {
+                    return;
+                }
+
+                // Hide original bar
+                Hud.instance.transform.Find("hudroot").Find(origBarName).gameObject.SetActive(false);
+
+                root = UnityEngine.Object.Instantiate(Hud.instance.m_healthBarRoot, Hud.instance.transform.Find("hudroot"));
+                root.gameObject.name = objectName;
+
+                int rot = 90 - (configRotation / 90 % 4 * 90);
+                root.localEulerAngles = new Vector3(0, 0, rot);
+
+                fastBar = root.Find("fast").GetComponent<GuiBar>();
+                slowBar = root.Find("slow").GetComponent<GuiBar>();
+
+                root.Find("fast").Find("bar").Find("HealthText").gameObject.SetActive(false);
+
+                barText = UnityEngine.Object.Instantiate(root.Find("fast").Find("bar").Find("HealthText").GetComponent<Text>(), root);
+                barText.GetComponent<RectTransform>().localEulerAngles = new Vector3(0, 0, -rot);
+
+                // Resize to a more "slim" rectangle - authors preference
+                barText.GetComponent<RectTransform>().localScale = new Vector3(scalingFactor, scalingFactor, 1f);
+                barText.gameObject.SetActive(true);
+
+                root.Find("border").GetComponent<RectTransform>().localScale = new Vector3(1f, scalingFactor, 1f);
+                root.Find("bkg").GetComponent<RectTransform>().localScale = new Vector3(1f, scalingFactor, 1f);
+
+                fastBar.GetComponent<RectTransform>().localScale = new Vector3(1f, scalingFactor, 1f);
+                slowBar.GetComponent<RectTransform>().localScale = new Vector3(1f, scalingFactor, 1f);
             }
-            else
+
+            public static void HealthStyleUpdate(float max, float current, ref GuiBar slowBar, ref GuiBar fastBar, ref Text barText)
             {
-              tmpText.text = Mathf.FloorToInt(food.m_time) + "s";
-              tmpText.color = new Color(1f, 1f, 1f, 0.4f + Mathf.Sin(Time.time * 10f) * 0.6f);
+                fastBar.SetMaxValue(max);
+                fastBar.SetValue(current);
+                slowBar.SetMaxValue(max);
+                slowBar.SetValue(current);
+
+                barText.text = $"{Mathf.CeilToInt(current)}/{Mathf.CeilToInt(max)}";
             }
-          }
-          else
-          {
-            Image tmpImage = foodBarRoot.Find(image.name).GetComponent<Image>();
-            Image tmpIcon = foodPanel.Find($"food{i}").Find($"foodicon{i}").GetComponent<Image>();
-            Text tmpText = foodPanel.Find($"food{i}").Find($"time").GetComponent<Text>();
-            tmpImage.gameObject.SetActive(false);
-            tmpIcon.gameObject.SetActive(false);
-            tmpText.gameObject.SetActive(false);
-          }
+
+            public static void StaminaStyleUpdate(float max, float current, ref GuiBar slowBar, ref GuiBar fastBar, ref Text barText)
+            {
+                fastBar.SetValue(current / max);
+                slowBar.SetValue(current / max);
+
+                barText.text = $"{Mathf.CeilToInt(current)}/{Mathf.CeilToInt(max)}";
+            }
         }
-        float size = Mathf.Ceil(player.GetMaxHealth() / 25f * 32f);
-        foodBarRoot.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, size);
-      }
+
+        public static class HealthBar
+        {
+            public static readonly string objectName = "BetterUI_HPBar";
+            internal static RectTransform root;
+            internal static GuiBar slowBar;
+            internal static GuiBar fastBar;
+            internal static Text barText;
+
+            public static void Create()
+            {
+                try
+                {
+                    BarHelper.BaseCreate(objectName, "healthpanel", Main.customHealthBarRotation.Value, ref root, ref slowBar, ref fastBar, ref barText);
+
+                    // go to a good default position that can get overriden by the editing feature if needed
+                    // go up and left
+                    root.position += new Vector3(-BarHelper.StepSize / 4, BarHelper.StepSize / 4);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(HealthBar)}.{nameof(Create)}() {e.Message}");
+                }
+            }
+
+            public static void Update(float max, float current)
+            {
+                try
+                {
+                    if (root != null)
+                    {
+                        BarHelper.HealthStyleUpdate(max, current, ref slowBar, ref fastBar, ref barText);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(HealthBar)}.{nameof(Update)}() {e.Message}");
+                }
+            }
+        }
+
+        public static class StaminaBar
+        {
+            public static readonly string objectName = "BetterUI_StaminaBar";
+            internal static RectTransform root;
+            internal static GuiBar slowBar;
+            internal static GuiBar fastBar;
+            internal static Text barText;
+
+            public static void Create()
+            {
+                try
+                {
+                    BarHelper.BaseCreate(objectName, "staminapanel", Main.customStaminaBarRotation.Value, ref root, ref slowBar, ref fastBar, ref barText);
+
+                    fastBar.m_originalColor = Hud.instance.m_staminaBar2Fast.m_bar.GetComponent<Image>().color;
+                    slowBar.m_originalColor = Hud.instance.m_staminaBar2Slow.m_bar.GetComponent<Image>().color;
+                    fastBar.ResetColor();
+                    slowBar.ResetColor();
+
+                    fastBar.m_smoothDrain = Hud.instance.m_staminaBar2Fast.m_smoothDrain;
+                    fastBar.m_changeDelay = Hud.instance.m_staminaBar2Fast.m_changeDelay;
+                    fastBar.m_smoothSpeed = Hud.instance.m_staminaBar2Fast.m_smoothSpeed;
+
+                    // go to a good default position that can get overriden by the editing feature if needed
+                    // go left
+                    root.position -= new Vector3(BarHelper.StepSize / 4, 0);
+
+                    if (Main.useCustomHealthBar.Value)
+                    {
+                        // hold positon
+                        root.position -= new Vector3(0, BarHelper.padding);
+                    }
+                    else
+                    {
+                        // go up
+                        root.position += new Vector3(0, BarHelper.StepSize / 4);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(StaminaBar)}.{nameof(Create)}() {e.Message}");
+                }
+            }
+
+            public static void Update(float max, float current)
+            {
+                try
+                {
+                    if (root != null)
+                    {
+                        BarHelper.StaminaStyleUpdate(max, current, ref slowBar, ref fastBar, ref barText);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(StaminaBar)}.{nameof(Update)}() {e.Message}");
+                }
+            }
+        }
+
+        public static class EitrBar
+        {
+            public static readonly string objectName = "BetterUI_EitrBar";
+            internal static RectTransform root;
+            internal static GuiBar slowBar;
+            internal static GuiBar fastBar;
+            internal static Text barText;
+
+            public static void Create()
+            {
+                try
+                {
+                    BarHelper.BaseCreate("BetterUI_EitrBar", "eitrpanel", Main.customSpoilerBarRotation.Value, ref root, ref slowBar, ref fastBar, ref barText);
+
+                    fastBar.m_originalColor = Hud.instance.m_eitrBarFast.m_bar.GetComponent<Image>().color;
+                    slowBar.m_originalColor = Hud.instance.m_eitrBarSlow.m_bar.GetComponent<Image>().color;
+                    fastBar.ResetColor();
+                    slowBar.ResetColor();
+
+                    fastBar.m_smoothDrain = Hud.instance.m_eitrBarFast.m_smoothDrain;
+                    fastBar.m_changeDelay = Hud.instance.m_eitrBarFast.m_changeDelay;
+                    fastBar.m_smoothSpeed = Hud.instance.m_eitrBarFast.m_smoothSpeed;
+
+                    // go to a good default position that can get overriden by the editing feature if needed
+                    // go left
+                    root.position -= new Vector3(BarHelper.StepSize / 4, 0);
+
+                    if (Main.useCustomHealthBar.Value)
+                    {
+                        // hold position
+                        root.position -= new Vector3(0, BarHelper.padding);
+
+                        if (Main.useCustomStaminaBar.Value)
+                        {
+                            // go down
+                            root.position -= new Vector3(0, BarHelper.StepSize / 4 + BarHelper.padding);
+                        }
+                    }
+                    else
+                    {
+                        // go up
+                        root.position += new Vector3(0, BarHelper.StepSize / 4);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(EitrBar)}.{nameof(Create)}() {e.Message}");
+                }
+            }
+
+            public static void Update(float max, float current)
+            {
+                try
+                {
+                    if (root != null)
+                    {
+                        BarHelper.StaminaStyleUpdate(max, current, ref slowBar, ref fastBar, ref barText);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(EitrBar)}.{nameof(Update)}() {e.Message}");
+                }
+            }
+        }
+
+        public static class FoodBar
+        {
+            public static readonly string objectName = "BetterUI_FoodBar";
+            private static RectTransform foodPanel;
+            private static RectTransform foodBarRoot;
+            public static RectTransform food0;
+            public static RectTransform food1;
+            public static RectTransform food2;
+
+            public static void Create()
+            {
+                try
+                {
+                    // we've obviously already done this before if it's not null
+                    if (foodPanel != null)
+                    {
+                        return;
+                    }
+
+                    // original food panel gets hidden by hiding the original health bar, so if the user doesn't use that feature, then they would have two food bars
+                    if (!Main.useCustomHealthBar.Value)
+                    {
+                        Debug.LogWarning($"{nameof(Main.useCustomFoodBar)} requires {nameof(Main.useCustomHealthBar)}. No custom food bar will be created. Activate {nameof(Main.useCustomHealthBar)} and log out and back in to use {nameof(Main.useCustomFoodBar)}.");
+                        return;
+                    }
+
+                    foodPanel = UnityEngine.Object.Instantiate(Hud.instance.m_healthPanel, Hud.instance.transform.Find("hudroot"));
+                    foodPanel.gameObject.name = objectName;
+                    foodPanel.gameObject.SetActive(true);
+                    int rot = 90 - (Main.customFoodBarRotation.Value / 90 % 4 * 90);
+                    foodPanel.localEulerAngles = new Vector3(0, 0, rot);
+
+                    foodBarRoot = foodPanel.Find("Food").GetComponent<RectTransform>();
+                    food0 = foodPanel.Find("food0").GetComponent<RectTransform>();
+                    food1 = foodPanel.Find("food1").GetComponent<RectTransform>();
+                    food2 = foodPanel.Find("food2").GetComponent<RectTransform>();
+
+                    food0.localEulerAngles = new Vector3(0, 0, -rot);
+                    food1.localEulerAngles = new Vector3(0, 0, -rot);
+                    food2.localEulerAngles = new Vector3(0, 0, -rot);
+
+                    // Stuff to remove / hide
+                    foodPanel.Find("Health").gameObject.SetActive(false);
+                    foodPanel.Find("darken").gameObject.SetActive(false);
+                    foodPanel.Find("healthicon").gameObject.SetActive(false);
+
+                    // hide the fork icon. mistlands renamed this one, probably from editor dropping a new version into the scene (might also explain why the armor icon had a fork icon)
+                    foodPanel.Find("foodicon (1)").gameObject.SetActive(false);
+
+                    foodPanel.position = Hud.instance.m_gpRoot.position;
+                    foodPanel.position += new Vector3(-foodPanel.sizeDelta.x / 4, foodPanel.sizeDelta.x / 2);
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(FoodBar)}.{nameof(Create)}() {e.Message}");
+                }
+            }
+
+            // based on HUD.UpdateFood()
+            public static void Update(Player player)
+            {
+                try
+                {
+                    if (foodPanel != null)
+                    {
+                        List<Player.Food> foods = player.GetFoods();
+                        float baseHP = player.GetBaseFoodHP() / 25f * 32f;
+                        foodBarRoot.Find("baseBar").GetComponent<RectTransform>().SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, baseHP);
+                        float barLength = baseHP;
+
+                        for (int i = 0; i < Hud.instance.m_foodBars.Length; i++)
+                        {
+                            Image image = foodBarRoot.Find(Hud.instance.m_foodBars[i].name).GetComponent<Image>();
+                            Image image2 = foodPanel.Find($"food{i}").Find($"foodicon{i}").GetComponent<Image>();
+                            Text text = foodPanel.Find($"food{i}").Find($"time").GetComponent<Text>();
+
+                            if (i < foods.Count)
+                            {
+                                image.gameObject.SetActive(true);
+                                Player.Food food = foods[i];
+                                image2.gameObject.SetActive(true);
+                                image2.sprite = food.m_item.GetIcon();
+
+                                if (food.CanEatAgain())
+                                {
+                                    image2.color = new Color(1f, 1f, 1f, 0.7f + Mathf.Sin(Time.time * 5f) * 0.3f);
+                                }
+                                else
+                                {
+                                    image2.color = Color.white;
+                                }
+
+                                text.gameObject.SetActive(true);
+
+                                if (food.m_time >= 60f)
+                                {
+                                    text.text = Mathf.CeilToInt(food.m_time / 60f) + "m";
+                                    text.color = Color.white;
+                                }
+                                else
+                                {
+                                    text.text = Mathf.FloorToInt(food.m_time) + "s";
+                                    text.color = new Color(1f, 1f, 1f, 0.4f + Mathf.Sin(Time.time * 10f) * 0.6f);
+                                }
+                            }
+                            else
+                            {
+                                image.gameObject.SetActive(false);
+                                image2.gameObject.SetActive(false);
+                                text.gameObject.SetActive(false);
+                            }
+                        }
+
+                        float size = Mathf.Ceil(player.GetMaxHealth() / 25f * 32f);
+                        foodBarRoot.SetSizeWithCurrentAnchors(RectTransform.Axis.Horizontal, size);
+                    }
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"{nameof(FoodBar)}.{nameof(Update)}() {e.Message}");
+                }
+            }
+        }
     }
-  }
 }

--- a/BetterUI/Patches/CustomHud.cs
+++ b/BetterUI/Patches/CustomHud.cs
@@ -37,6 +37,7 @@ namespace BetterUI.Patches
       new Element(CustomElements.HealthBar.objectName, Groups.HudRoot, CustomElements.HealthBar.objectName, "HP Bar"),
       new Element(CustomElements.FoodBar.objectName, Groups.HudRoot, CustomElements.FoodBar.objectName, "Food Bar"),
       new Element(CustomElements.StaminaBar.objectName, Groups.HudRoot, CustomElements.StaminaBar.objectName, "Stamina Bar"),
+      new Element(CustomElements.EitrBar.objectName, Groups.HudRoot, CustomElements.EitrBar.objectName, "Eitr Bar"),
       new Element("QuickSlots", Groups.HudRoot, "QuickSlotsHotkeyBar", "QuickSlots")
       //new Element("QuickSlotsHotkeyBar", Groups.HudRoot, "healthpanel/Health/QuickSlotsHotkeyBar", "QuickSlotsHotkey"),
       //new Element("QuickSlotGrid", Groups.Inventory, "Player/QuickSlotGrid", "QuickSlots"),

--- a/BetterUI/Patches/CustomHud.cs
+++ b/BetterUI/Patches/CustomHud.cs
@@ -1,26 +1,23 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.UI;
 
 namespace BetterUI.Patches
 {
-  static class CustomHud
-  {
-    public static List<HudElement> elements;
-    public static Dictionary<Groups, Transform> roots = new Dictionary<Groups, Transform>();
-    public static Dictionary<Groups, Transform> templates = new Dictionary<Groups, Transform>();
-    private static Transform hudRoot;
-    private static Transform invRoot;
-    private static Transform baseRoot;
-    public static readonly string templateSuffix = "_template";
-
-    // In the future give users ability to add new elements?
-    private static readonly Element[] supportedElements =
+    internal static class CustomHud
     {
+        public static List<HudElement> elements;
+        public static Dictionary<Groups, Transform> roots = new Dictionary<Groups, Transform>();
+        public static Dictionary<Groups, Transform> templates = new Dictionary<Groups, Transform>();
+        private static Transform hudRoot;
+        private static Transform invRoot;
+        private static Transform baseRoot;
+        public static readonly string templateSuffix = "_template";
+
+        // In the future give users ability to add new elements?
+        private static readonly Element[] supportedElements =
+        {
       new Element("HotKeyBar", Groups.HudRoot),
       new Element("BuildHud", Groups.HudRoot, "BuildHud/SelectedInfo"),
       new Element("MiniMap", Groups.HudRoot, "MiniMap/small"),
@@ -34,429 +31,315 @@ namespace BetterUI.Patches
       new Element("Container", Groups.Inventory, "Container", "ChestContainer"),
       new Element("Info", Groups.Inventory, "Info", "UITab"),
       new Element("Crafting", Groups.Inventory, "Crafting", "CraftingWindow"),
-      new Element(CustomElements.HealthBar.objectName, Groups.HudRoot, CustomElements.HealthBar.objectName, "HP Bar"),
-      new Element(CustomElements.FoodBar.objectName, Groups.HudRoot, CustomElements.FoodBar.objectName, "Food Bar"),
-      new Element(CustomElements.StaminaBar.objectName, Groups.HudRoot, CustomElements.StaminaBar.objectName, "Stamina Bar"),
-      new Element(CustomElements.EitrBar.objectName, Groups.HudRoot, CustomElements.EitrBar.objectName, "Eitr Bar"),
+      new Element(CustomBars.HealthBar.objectName, Groups.HudRoot, CustomBars.HealthBar.objectName, "HP Bar"),
+      new Element(CustomBars.FoodBar.objectName, Groups.HudRoot, CustomBars.FoodBar.objectName, "Food Bar"),
+      new Element(CustomBars.StaminaBar.objectName, Groups.HudRoot, CustomBars.StaminaBar.objectName, "Stamina Bar"),
+      new Element(CustomBars.EitrBar.objectName, Groups.HudRoot, CustomBars.EitrBar.objectName, "Eitr Bar"),
       new Element("QuickSlots", Groups.HudRoot, "QuickSlotsHotkeyBar", "QuickSlots")
       //new Element("QuickSlotsHotkeyBar", Groups.HudRoot, "healthpanel/Health/QuickSlotsHotkeyBar", "QuickSlotsHotkey"),
       //new Element("QuickSlotGrid", Groups.Inventory, "Player/QuickSlotGrid", "QuickSlots"),
       //new Element("EquipmentSlotGrid", Groups.Inventory, "Player/EquipmentSlotGrid", "EquipmentSlots"),
     };
 
-    // If new items are added to mandatory items, check if user has them - if not add them.
-    public static void Load(Hud hud)
-    {
-      try
-      {
-        hudRoot = hud.transform.Find("hudroot");
-        invRoot = InventoryGui.instance.transform.Find("root"); // Issue, this element is hidden when inventory is closed
-        baseRoot = MessageHud.instance.transform; // This layer will be projected over other UI elements
-
-        roots[Groups.HudRoot] = hudRoot;
-        roots[Groups.Inventory] = invRoot;
-
-
-        if (Main.uiData.Value == "none" || Main.uiData.Value == "")
+        // If new items are added to mandatory items, check if user has them - if not add them.
+        public static void Load(Hud hud)
         {
-          Helpers.DebugLine($"User has no uiData. Creating basic template.");
-          elements = new List<HudElement>();
-        }
-        else
-        {
-          try
-          {
-            byte[] bytes = Convert.FromBase64String(Main.uiData.Value);
-            elements = (List<HudElement>)bytes.DeSerialize(); // Risky, as we trust the data is valid?
-            Helpers.DebugLine($"User has {elements.Count} ui elements set.");
-          }
-          catch
-          {
-            Helpers.DebugLine($"FAILED to DeSerialize uiData: {Main.uiData.Value}");
-          }
-        }
-
-        if (elements.Count < supportedElements.Length)
-        {
-          foreach (Element e in supportedElements)
-          {
-            // Element does not exist in users uiData, add it.
-            if (!elements.Exists(he => he.name == e.name))
+            try
             {
-              Helpers.DebugLine($"Adding to elements: {e.name}");
-              elements.Add(new HudElement(e.name, Vector2.zero, 1f, 1f, e.displayName, e.group, e.locationPath));
+                hudRoot = hud.transform.Find("hudroot");
+                invRoot = InventoryGui.instance.transform.Find("root"); // Issue, this element is hidden when inventory is closed
+                baseRoot = MessageHud.instance.transform; // This layer will be projected over other UI elements
 
-              if (elements.Count == supportedElements.Length) break;
+                roots[Groups.HudRoot] = hudRoot;
+                roots[Groups.Inventory] = invRoot;
+
+                if (Main.uiData.Value == "none" || Main.uiData.Value == "")
+                {
+                    Helpers.DebugLine($"User has no uiData. Creating basic template.");
+                    elements = new List<HudElement>();
+                }
+                else
+                {
+                    try
+                    {
+                        byte[] bytes = Convert.FromBase64String(Main.uiData.Value);
+                        elements = (List<HudElement>)bytes.DeSerialize(); // Risky, as we trust the data is valid?
+                        Helpers.DebugLine($"User has {elements.Count} ui elements set.");
+                    }
+                    catch
+                    {
+                        Helpers.DebugLine($"FAILED to DeSerialize uiData: {Main.uiData.Value}");
+                    }
+
+                    foreach (var item in elements)
+                    {
+                        item.OnAfterDeserialize();
+                    }
+                }
+
+                if (elements.Count < supportedElements.Length)
+                {
+                    foreach (Element e in supportedElements)
+                    {
+                        // Element does not exist in users uiData, add it.
+                        if (!elements.Exists(he => he.Name == e.Name))
+                        {
+                            Helpers.DebugLine($"Adding to elements: {e.Name}");
+                            elements.Add(new HudElement(e.Name, e.DisplayName, e.Group, e.LocationPath, Vector2.zero));
+
+                            if (elements.Count == supportedElements.Length) break;
+                        }
+                    }
+                }
+                else if (elements.Count > supportedElements.Length)
+                {
+                    // We have more elements than supported? Are there duplicates, how?
+                    Helpers.DebugLine($"Seems that your UI might be corrupted!", true, true);
+                }
+
+                CreateTemplates();
             }
-          }
-        }
-        else if (elements.Count > supportedElements.Length)
-        {
-          // We have more elements than supported? Are there duplicates, how?
-          Helpers.DebugLine($"Seems that your UI might be corrupted!", true, true);
-        }
-
-        CreateTemplates();
-      }
-      catch (Exception e)
-      {
-        Helpers.DebugLine($"Issue while CustomHud Load. {e.Message}", true, true);
-      }
-    }
-
-    public static void Save()
-    {
-      try
-      {
-        // Before saving, check if unset elements -> no need to save them.
-        elements.RemoveAll(e => e.GetPosition() == Vector2.zero);
-        byte[] bytes = elements.Serialize();
-        Helpers.DebugLine($"uiData bytes: {bytes.Length}");
-        string base64String = Convert.ToBase64String(bytes);
-        Main.uiData.Value = base64String;
-      }
-      catch (Exception e)
-      {
-        Helpers.DebugLine($"FAILED to Save: {e.Message}");
-      }
-    }
-
-    public static void ShowTemplates(bool show, int activeLayer)
-    {
-      // Try to find reason on using this?
-      roots.TryGetValue((Groups)activeLayer, out Transform activeTemplate);
-
-      foreach (HudElement e in elements)
-      {
-        if ((Groups)activeLayer == e.group)
-        {
-          RectTransform rt = LocateTemplateRect(e.group, e.name);
-          if (rt)
-          {
-            rt.gameObject.SetActive(show);
-          }
-        }
-        else
-        {
-          RectTransform rt = LocateTemplateRect(e.group, e.name);
-          if (rt)
-          {
-            rt.gameObject.SetActive(false);
-          }
-        }
-      }
-
-
-      if (!show) Save();
-    }
-
-    public static void UpdatePosition(string name, Vector3 pos, float size)
-    {
-      HudElement element = elements.Find(e => e.name == name);
-      if (element.name == name)
-      {
-        element.x += pos.x;
-        element.y += pos.y;
-        if (size != 0f)
-        {
-          element.SetScale(size);
-          Player.m_localPlayer.Message(MessageHud.MessageType.Center, $"{element.displayName} size: {element.scale}");
-        }
-        if (element.group == Groups.Inventory)
-        {
-          Vector3 newPos = Camera.main.ScreenToViewportPoint(new Vector3(pos.x, pos.y, pos.z));
-          //element.SetAnchors(newPos, newPos);
-          //element.anchorMin += new Vector2(newPos.x, newPos.y);
-          element.UpdateAnchors(newPos, newPos);
-          //element.anchorMax += new Vector2(newPos.x, newPos.y);
-        }
-        // Update element & template position
-        PositionTemplate(element);
-      }
-    }
-
-    // This creates issues with Text. Scaling is off!
-    public static void UpdateDimensions(string name, float size)
-    {
-      HudElement element = elements.Find(e => e.name == name);
-      if (element.name == name)
-      {
-        if (size != 0f)
-        {
-          element.SetDims(size);
-          Player.m_localPlayer.Message(MessageHud.MessageType.Center, $"{element.displayName} dimensions: (1,{element.dimensions})");
-          // Update element & template position
-          PositionTemplate(element);
-        }
-      }
-      else
-      {
-        Helpers.DebugLine($"Invalid call when updating element: {name}", true, true);
-      }
-    }
-
-    private static void PositionTemplate(HudElement e)
-    {
-      try
-      {
-        RectTransform rt = LocateRectTransform(e.group, e.path);  // Original object
-        RectTransform tt = LocateTemplateRect(e.group, e.name);   // Your generated template
-        //Helpers.DebugLine($"{rt} {rt.anchorMin} {e.GetPosition()}");
-        if (rt)
-        {
-          if (e.group == Groups.Inventory)
-          {
-            float gameScale = GameObject.Find("LoadingGUI").GetComponent<CanvasScaler>().scaleFactor;
-            //Helpers.DebugLine($"\n{e.GetPosition()}\n{gameScale}\n{Camera.main.ViewportToScreenPoint(e.GetAnchorMin())}\n{tt.position}");
-            //Helpers.DebugLine($"\n{e.GetPosition() / gameScale}");
-            // Original object are moved by anchors
-            Vector3 cPos = Camera.main.ViewportToScreenPoint(e.GetAnchorMax());
-            Vector2 ePos = e.GetPosition();
-
-            rt.anchorMin = e.GetAnchorMin();
-            rt.anchorMax = e.GetAnchorMax();
-            tt.anchoredPosition = e.GetPosition() / gameScale;
-          }
-          else
-          {
-            rt.anchoredPosition = e.GetPosition();
-            tt.anchoredPosition = e.GetPosition(); //rt.anchoredPosition;
-          }
-          rt.localScale = new Vector3(e.GetScale(), e.GetScale() * e.GetDims());
-          tt.localScale = rt.localScale;
-        }
-      }
-      catch
-      {
-        Helpers.DebugLine($"PositionTemplate Catch: {e.name}");
-      }
-    }
-
-    public static RectTransform LocateRectTransform(Groups group, string path)
-    {
-      try
-      {
-        roots.TryGetValue(group, out Transform parent);
-        // We change parent to Inventory root
-        if (group == Groups.Inventory) parent = InventoryGui.instance.transform.Find("root");
-
-        return parent.Find(path).GetComponent<RectTransform>();
-      }
-      catch
-      {
-        return null;
-      }
-    }
-
-    public static RectTransform LocateTemplateRect(Groups group, string name)
-    {
-      try
-      {
-        return baseRoot.Find($"{name}{templateSuffix}").GetComponent<RectTransform>();
-      }
-      catch
-      {
-        Helpers.DebugLine($"Unable to find template for {name}", true, true);
-        return null;
-      }
-    }
-
-    public static void PositionTemplates()
-    {
-      foreach (HudElement e in elements) PositionTemplate(e);
-    }
-
-    private static void CreateTemplates()
-    {
-      List<HudElement> unusedElements = new List<HudElement>();
-      foreach (HudElement e in elements)
-      {
-        try
-        {
-          RectTransform rt = LocateRectTransform(e.group, e.path);
-          if (e.GetPosition() == Vector2.zero)
-          {
-            if (e.group == Groups.Inventory)
+            catch (Exception e)
             {
-              e.SetPosition(rt.anchoredPosition);
-              // This elements depend on anchors, set these
-              e.SetAnchors(rt.anchorMin, rt.anchorMax);
-              //e.SetPosition(rt.anchorMax);
+                Helpers.DebugLine($"Issue while CustomHud Load. {e.Message}", true, true);
+            }
+        }
+
+        public static void Save()
+        {
+            try
+            {
+                // Before saving, check if unset elements -> no need to save them.
+                elements.RemoveAll(e => e.Position == Vector2.zero);
+                byte[] bytes = elements.Serialize();
+                Helpers.DebugLine($"uiData bytes: {bytes.Length}");
+                string base64String = Convert.ToBase64String(bytes);
+                Main.uiData.Value = base64String;
+            }
+            catch (Exception e)
+            {
+                Helpers.DebugLine($"FAILED to Save: {e.Message}");
+            }
+        }
+
+        public static void ShowTemplates(bool show, int activeLayer)
+        {
+            // Try to find reason on using this?
+            //roots.TryGetValue((Groups)activeLayer, out Transform activeTemplate);
+
+            foreach (HudElement e in elements)
+            {
+                if ((Groups)activeLayer == e.Group)
+                {
+                    RectTransform rt = LocateTemplateRect(e.Name);
+                    if (rt)
+                    {
+                        rt.gameObject.SetActive(show);
+                    }
+                }
+                else
+                {
+                    RectTransform rt = LocateTemplateRect(e.Name);
+                    if (rt)
+                    {
+                        rt.gameObject.SetActive(false);
+                    }
+                }
+            }
+
+            if (!show) Save();
+        }
+
+        public static void UpdatePosition(string name, Vector2 posChange)
+        {
+            HudElement element = elements.Find(e => e.Name == name);
+
+            if (element.Name == name)
+            {
+                element.Position += posChange;
+
+                if (element.Group == Groups.Inventory)
+                {
+                    var newPos = (Vector2)Camera.main.ScreenToViewportPoint(posChange);
+
+                    element.AnchorMin += newPos;
+                    element.AnchorMax += newPos;
+                }
+
+                // Update element & template position
+                PositionTemplate(element);
+            }
+        }
+
+        public static void UpdateScaleAndDimensions(string name, Vector2 dimensionChanges, float scaleChange)
+        {
+            HudElement element = elements.Find(e => e.Name == name);
+
+            if (element.Name == name)
+            {
+                if (scaleChange != 0f)
+                {
+                    element.ChangeScale(scaleChange);
+                    Player.m_localPlayer.Message(MessageHud.MessageType.Center, $"{element.DisplayName} size: {element.Scale}");
+                }
+
+                if (dimensionChanges != Vector2.zero)
+                {
+                    element.ChangeXDims(dimensionChanges.x);
+                    element.ChangeYDims(dimensionChanges.y);
+                    Player.m_localPlayer.Message(MessageHud.MessageType.Center, $"{element.DisplayName} dimensions: ({element.XDimensions},{element.YDimensions})");
+                    // Update element & template position
+                    PositionTemplate(element);
+                }
             }
             else
             {
-              e.SetPosition(rt.anchoredPosition);
+                Helpers.DebugLine($"Invalid call when updating element: {name}", true, true);
             }
-          }
-          AddTemplateToHud(e, rt);
         }
-        catch
+
+        private static void PositionTemplate(HudElement e)
         {
-          unusedElements.Add(e);
+            try
+            {
+                RectTransform rt = LocateRectTransform(e.Group, e.Path);  // Original object
+                RectTransform tt = LocateTemplateRect(e.Name);   // Your generated template
+                                                                 //Helpers.DebugLine($"{rt} {rt.anchorMin} {e.GetPosition()}");
+                if (rt)
+                {
+                    if (e.Group == Groups.Inventory)
+                    {
+                        float gameScale = GameObject.Find("LoadingGUI").GetComponent<CanvasScaler>().scaleFactor;
+                        //Helpers.DebugLine($"\n{e.GetPosition()}\n{gameScale}\n{Camera.main.ViewportToScreenPoint(e.GetAnchorMin())}\n{tt.position}");
+                        //Helpers.DebugLine($"\n{e.GetPosition() / gameScale}");
+                        // Original object are moved by anchors
+                        Vector3 cPos = Camera.main.ViewportToScreenPoint(e.AnchorMax);
+                        Vector2 ePos = e.Position;
+
+                        rt.anchorMin = e.AnchorMin;
+                        rt.anchorMax = e.AnchorMax;
+                        tt.anchoredPosition = e.Position / gameScale;
+                    }
+                    else
+                    {
+                        rt.anchoredPosition = e.Position;
+                        tt.anchoredPosition = e.Position; //rt.anchoredPosition;
+                    }
+
+                    rt.localScale = new Vector3(e.Scale * e.XDimensions, e.Scale * e.YDimensions);
+                    tt.localScale = rt.localScale;
+                }
+            }
+            catch
+            {
+                Helpers.DebugLine($"PositionTemplate Catch: {e.Name}");
+            }
         }
-      }
-      // Remove unused elements from main ElementList
-      if (unusedElements.Count > 0)
-      {
-        Helpers.DebugLine($"Removing {unusedElements.Count} unused elements.");
-        foreach (HudElement e in unusedElements)
+
+        public static RectTransform LocateRectTransform(Groups group, string path)
         {
-          Helpers.DebugLine($"Remove {e.displayName} as not used.");
-          elements.Remove(e);
+            try
+            {
+                roots.TryGetValue(group, out Transform parent);
+                // We change parent to Inventory root
+                if (group == Groups.Inventory) parent = InventoryGui.instance.transform.Find("root");
+
+                return parent.Find(path).GetComponent<RectTransform>();
+            }
+            catch
+            {
+                return null;
+            }
         }
-      }
+
+        public static RectTransform LocateTemplateRect(string name)
+        {
+            try
+            {
+                return baseRoot.Find($"{name}{templateSuffix}").GetComponent<RectTransform>();
+            }
+            catch
+            {
+                Helpers.DebugLine($"Unable to find template for {name}", true, true);
+                return null;
+            }
+        }
+
+        public static void PositionTemplates()
+        {
+            foreach (HudElement e in elements) PositionTemplate(e);
+        }
+
+        private static void CreateTemplates()
+        {
+            List<HudElement> unusedElements = new List<HudElement>();
+            foreach (HudElement e in elements)
+            {
+                try
+                {
+                    RectTransform rt = LocateRectTransform(e.Group, e.Path);
+                    if (e.Position == Vector2.zero)
+                    {
+                        if (e.Group == Groups.Inventory)
+                        {
+                            e.Position = rt.anchoredPosition;
+                            // This elements depend on anchors, set these
+                            e.AnchorMin = rt.anchorMin;
+                            e.AnchorMax = rt.anchorMax;
+                        }
+                        else
+                        {
+                            e.Position = rt.anchoredPosition;
+                        }
+                    }
+                    AddTemplateToHud(e, rt);
+                }
+                catch
+                {
+                    unusedElements.Add(e);
+                }
+            }
+            // Remove unused elements from main ElementList
+            if (unusedElements.Count > 0)
+            {
+                Helpers.DebugLine($"Removing {unusedElements.Count} unused elements.");
+                foreach (HudElement e in unusedElements)
+                {
+                    Helpers.DebugLine($"Remove {e.DisplayName} as not used.");
+                    elements.Remove(e);
+                }
+            }
+        }
+
+        private static void AddTemplateToHud(HudElement element, RectTransform rt)
+        {
+            // Should we add these to their own elements? Based on their group?
+            // roots.TryGetValue(Groups.HudRoot, out Transform templateRoot); // Everything on hudRoot
+            // roots.TryGetValue(element.group, out Transform templateRoot);
+
+            Transform go = UnityEngine.Object.Instantiate(hudRoot.Find("BuildHud/SelectedInfo"), baseRoot);
+            go.gameObject.name = $"{element.Name}{templateSuffix}";
+            go.Find("selected_piece").gameObject.SetActive(false);
+            go.Find("requirements").gameObject.SetActive(false);
+
+            Text t = go.gameObject.AddComponent<Text>();
+            t.text = $"{element.DisplayName}";
+            t.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
+            t.fontSize = 20;
+            t.alignment = TextAnchor.MiddleCenter;
+            go.gameObject.SetActive(false); // Have it hidden when added
+
+            RectTransform templateRT = go.GetComponent<RectTransform>();
+            templateRT.pivot = rt.pivot;
+            templateRT.anchorMin = rt.anchorMin;
+            templateRT.anchorMax = rt.anchorMax;
+            templateRT.offsetMin = rt.offsetMin;
+            templateRT.offsetMax = rt.offsetMax;
+            templateRT.sizeDelta = rt.sizeDelta;
+            templateRT.anchoredPosition = rt.anchoredPosition;
+            templateRT.position = rt.position;
+            templateRT.localEulerAngles = rt.localEulerAngles;
+            t.resizeTextForBestFit = true;
+        }
     }
-
-    private static void AddTemplateToHud(HudElement element, RectTransform rt)
-    {
-      // Should we add these to their own elements? Based on their group?
-      // roots.TryGetValue(Groups.HudRoot, out Transform templateRoot); // Everything on hudRoot
-      // roots.TryGetValue(element.group, out Transform templateRoot);
-
-
-      Transform go = UnityEngine.Object.Instantiate(hudRoot.Find("BuildHud/SelectedInfo"), baseRoot);
-      go.gameObject.name = $"{element.name}{templateSuffix}";
-      go.Find("selected_piece").gameObject.SetActive(false);
-      go.Find("requirements").gameObject.SetActive(false);
-
-      Text t = go.gameObject.AddComponent<Text>();
-      t.text = $"{element.displayName}";
-      t.font = Resources.GetBuiltinResource<Font>("Arial.ttf");
-      t.fontSize = 20;
-      t.alignment = TextAnchor.MiddleCenter;
-      go.gameObject.SetActive(false); // Have it hidden when added
-
-      RectTransform templateRT = go.GetComponent<RectTransform>();
-      templateRT.pivot = rt.pivot;
-      templateRT.anchorMin = rt.anchorMin;
-      templateRT.anchorMax = rt.anchorMax;
-      templateRT.offsetMin = rt.offsetMin;
-      templateRT.offsetMax = rt.offsetMax;
-      templateRT.sizeDelta = rt.sizeDelta;
-      templateRT.anchoredPosition = rt.anchoredPosition;
-      templateRT.position = rt.position;
-      templateRT.localEulerAngles = rt.localEulerAngles;
-      t.resizeTextForBestFit = true;
-    }
-  }
-
-  [Serializable]
-  public class HudElement
-  {
-    public string name;
-    public string displayName;
-    public float x;
-    public float y;
-    public float scale;
-    public float dimensions;
-
-    public string path;
-    /// <summary>
-    /// Layer Group where the element belongs
-    /// </summary>
-    public Groups group;
-    // AnchorMin
-    private float anchorMinX;
-    private float anchorMinY;
-    // AnchorMax
-    private float anchorMaxX;
-    private float anchorMaxY;
-
-
-    public HudElement(string name, Vector2 position, float scale, float dimensions, string displayName, Groups group, string path)
-    {
-      this.name = name;
-      this.displayName = displayName;
-      this.x = position.x;
-      this.y = position.y;
-      this.scale = scale;
-      this.dimensions = dimensions;
-      this.path = path;
-      this.group = group;
-    }
-
-    public string GetName() => name;
-    public string SetName(string name) => this.name = name;
-    public Vector2 GetPosition() => new Vector2(x, y);
-    public void SetPosition(Vector2 pos)
-    {
-      x = pos.x;
-      y = pos.y;
-    }
-    public float GetScale() => scale;
-    public void SetScale(float change)
-    {
-      scale = (float)Math.Round(Mathf.Abs(scale + change), 1);
-    }
-    public float GetDims() => dimensions;
-    public void SetDims(float change)
-    {
-      dimensions = (float)Math.Round(Mathf.Abs(dimensions + change), 2);
-    }
-
-    public void SetAnchors(Vector2 min, Vector2 max)
-    {
-      this.anchorMinX = min.x;
-      this.anchorMinY = min.y;
-      this.anchorMaxX = max.x;
-      this.anchorMaxY = max.y;
-    }
-    public void UpdateAnchors(Vector2 min, Vector2 max)
-    {
-      this.anchorMinX += min.x;
-      this.anchorMinY += min.y;
-      this.anchorMaxX += max.x;
-      this.anchorMaxY += max.y;
-    }
-    public Vector2 GetAnchorMin() => new Vector2(anchorMinX, anchorMinY);
-    public Vector2 GetAnchorMax() => new Vector2(anchorMaxX, anchorMaxY);
-  }
-
-  public struct Element
-  {
-    /// <summary>
-    /// Used as an unique value, unique name to the element.
-    /// If no path is given, this needs to be elements path as well.
-    /// </summary>
-    public string name; // We see this as unique. Might cause issues later on?
-    /// <summary>
-    /// Use custom name on the template when user edits HUD
-    /// </summary>
-    public string displayName;
-    /// <summary>
-    /// On what layer group should the element be editable. This is as well the parent element where path is related.
-    /// </summary>
-    public Groups group;
-    /// <summary>
-    /// Path of the element. Relative to parent.
-    /// </summary>
-    public string locationPath;
-
-    public Element(string name, Groups group, string locationPath = "", string displayName = "")
-    {
-      this.name = name;
-      this.group = group;
-      this.locationPath = locationPath == "" ? name : locationPath;
-      this.displayName = displayName == "" ? name : displayName;
-    }
-  };
-
-  public enum Groups
-  {
-    HudRoot,
-    Inventory,
-    Other // Is this enough, or should we just specify everything.
-  }
-
-  public enum ParentRoot
-  {
-    Hud,
-    Inventory,
-    HudMessage,
-    TopLeftMessage,
-    Chat,
-    EnemyHud,
-    Store,
-    Menu
-  }
 }

--- a/BetterUI/Patches/HoverText.cs
+++ b/BetterUI/Patches/HoverText.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using static BetterUI.Main;
 
 namespace BetterUI.Patches
 {
@@ -25,7 +26,7 @@ namespace BetterUI.Patches
             hoverText = Localization.instance.Localize(fermenter.m_name + " ( " + contentName + ", $piece_fermenter_exposed )");
             return false;
           }
-          string time = Main.timeLeftStyleFermenter.Value == 1 ?
+          string time = Main.timeLeftHoverTextFermenter.Value == Main.TimeLeftStyle.PercentageDone ?
             $"{fermenter.GetFermentationTime() / fermenter.m_fermentationDuration:P0}" :
             Helpers.TimeString(fermenter.m_fermentationDuration - fermenter.GetFermentationTime());
 
@@ -42,12 +43,44 @@ namespace BetterUI.Patches
       }
     }
 
+        public static void PatchBeeHive(Beehive beeHive, ref string hoverText)
+        {
+            int honeyLevel = beeHive.GetHoneyLevel();
+
+            var timeLeft = string.Empty;
+
+            if (honeyLevel < beeHive.m_maxHoney)
+            {
+                float num = beeHive.m_nview.GetZDO().GetFloat("product");
+
+                float durationUntilDone = beeHive.m_secPerUnit - num;
+
+                if (Main.timeLeftHoverTextBeeHive.Value == Main.TimeLeftStyle.PercentageDone)
+                {
+                    timeLeft = $"{num / beeHive.m_secPerUnit:P0}, ";
+                }
+                else
+                {
+                    timeLeft = $"{Helpers.TimeString(durationUntilDone)}, ";
+                }
+            }
+
+            if (honeyLevel > 0)
+            {
+                hoverText = Localization.instance.Localize($"{beeHive.m_name} ( {timeLeft}{beeHive.m_honeyItem.m_itemData.m_shared.m_name} x {honeyLevel} ) \n[<color=yellow><b>$KEY_Use</b></color>] $piece_beehive_extract");
+            }
+            else
+            {
+                hoverText = Localization.instance.Localize($"{beeHive.m_name} ( {timeLeft}$piece_container_empty ) \n[<color=yellow><b>$KEY_Use</b></color>] $piece_beehive_check");
+            }
+        }
+
     public static bool PatchPlant(Plant plant, ref string hoverText)
     {
       switch (plant.m_status)
       {
         case Plant.Status.Healthy:
-          string time = Main.timeLeftStylePlant.Value == 1 ?
+          string time = Main.timeLeftHoverTextPlant.Value == Main.TimeLeftStyle.PercentageDone ?
             $"{plant.TimeSincePlanted() / plant.GetGrowTime():P0}" :
             Helpers.TimeString(plant.GetGrowTime() - plant.TimeSincePlanted());
 
@@ -66,16 +99,16 @@ namespace BetterUI.Patches
         $"{container.m_inventory.SlotsUsedPercentage():F0}%" : 
         $"{container.m_inventory.NrOfItems()}/{container.m_inventory.GetWidth() * container.m_inventory.GetHeight()}";
       */
-      string room;
-      switch (Main.chestHasRoomStyle.Value)
+        string room;
+      switch (Main.chestHasRoomHoverText.Value)
       {
-        case 1:
+        case ChestHasRoomStyle.Percentage:
           room = $"{container.m_inventory.SlotsUsedPercentage():F0}%";
           break;
-        case 2:
+        case ChestHasRoomStyle.ItemsSlashMaxRoom:
           room = $"{container.m_inventory.NrOfItems()}/{container.m_inventory.GetWidth() * container.m_inventory.GetHeight()}";
           break;
-        case 3:
+        case ChestHasRoomStyle.AmountOfFreeSlots:
           room = $"{container.m_inventory.GetEmptySlots()}";
           break;
         default:
@@ -103,12 +136,12 @@ namespace BetterUI.Patches
               items++;
               if (num > itemConversion.m_cookTime) // Item overCooking
               {
-                string time = Main.timeLeftStyleCookingStation.Value == 1 ? $"{num / (itemConversion.m_cookTime * 2f):P0}" : Helpers.TimeString(itemConversion.m_cookTime * 2f - num);
+                string time = Main.timeLeftHoverTextCookingStation.Value == Main.TimeLeftStyle.PercentageDone ? $"{num / (itemConversion.m_cookTime * 2f):P0}" : Helpers.TimeString(itemConversion.m_cookTime * 2f - num);
                 cookingItems += $"\n{cookingStation.m_overCookedItem.GetHoverName()}: <color={overCookColor}>{time}</color>";
               }
               else
               {
-                string time = Main.timeLeftStyleCookingStation.Value == 1 ? $"{num / itemConversion.m_cookTime:P0}" : Helpers.TimeString(itemConversion.m_cookTime - num);
+                string time = Main.timeLeftHoverTextCookingStation.Value == Main.TimeLeftStyle.PercentageDone ? $"{num / itemConversion.m_cookTime:P0}" : Helpers.TimeString(itemConversion.m_cookTime - num);
                 cookingItems += $"\n{itemConversion.m_to.GetHoverName()}: {time}";
               }
             }

--- a/BetterUI/Patches/HudElement.cs
+++ b/BetterUI/Patches/HudElement.cs
@@ -1,0 +1,156 @@
+﻿using System;
+using UnityEngine;
+
+namespace BetterUI.Patches
+{
+    [Serializable]
+    public class HudElement
+    {
+        // the serialization is NOT done with the unity serializer, so private members ARE serialized, and SerializeField, ISerializationCallbackReceiver and FormerlySerializedAs do not work
+
+        private readonly string name;
+        private readonly string displayName;
+        private readonly string path;
+
+        /// <summary>
+        /// Layer Group where the element belongs
+        /// </summary>
+        private readonly Groups group;
+
+        private float x;
+        private float y;
+        private float scale;
+
+        // DO NOT rename this field. keep it as 'dimensions'. The deserialization used is NOT unity deserialization, so FormerlySerializedAs does NOT work
+        private float dimensions;
+
+        private float xDimensions;
+
+        // AnchorMin
+        private float anchorMinX;
+
+        private float anchorMinY;
+
+        // AnchorMax
+        private float anchorMaxX;
+
+        private float anchorMaxY;
+
+        public HudElement(string name, string displayName, Groups group, string path, Vector2 position, float scale = 1f, float xDimensions = 1f, float yDimensions = 1f)
+        {
+            this.name = name;
+            this.displayName = displayName;
+            this.path = path;
+            this.group = group;
+
+            this.x = position.x;
+            this.y = position.y;
+            this.scale = scale;
+            this.xDimensions = xDimensions;
+            this.dimensions = yDimensions;
+        }
+
+        // intentionally no setter
+        public string Name { get => this.name; }
+        public string DisplayName { get => this.displayName; }
+        public string Path { get => this.path; }
+        public Groups Group { get => this.group; }
+
+        public Vector2 Position { get => new Vector2(this.x, this.y); set { this.x = value.x; this.y = value.y; } }
+
+        public Vector2 AnchorMin { get => new Vector2(anchorMinX, anchorMinY); set { this.anchorMinX = value.x; this.anchorMinY = value.y; } }
+        public Vector2 AnchorMax { get => new Vector2(anchorMaxX, anchorMaxY); set { this.anchorMaxX = value.x; this.anchorMaxY = value.y; } }
+
+        public float Scale { get => this.scale; }
+
+        public float XDimensions { get => this.xDimensions; }
+        public float YDimensions { get => this.dimensions; }
+
+        // scale == 0 is intentionally still allowed
+        public void ChangeScale(float change)
+        {
+            scale = (float)Math.Round(Mathf.Abs(scale + change), 1);
+        }
+
+        public void ChangeXDims(float change)
+        {
+            xDimensions = Mathf.Max(0.1f, (float)Math.Round(Mathf.Abs(xDimensions + change), 2));
+        }
+
+        public void ChangeYDims(float change)
+        {
+            dimensions = Mathf.Max(0.1f, (float)Math.Round(Mathf.Abs(dimensions + change), 2));
+        }
+
+        // called manually in CustomHud.Load because unitys ISerializationCallbackReceiver does not work with the used deserializer
+        public void OnAfterDeserialize()
+        {
+            // this especially catches backwards compatibility, because all older setups will have xDimensions == 0 (default values do not work with the deserializer), so keep this as xDimensions = 1f;
+            if (xDimensions < 0.1f)
+            {
+                xDimensions = 1f;
+            }
+
+            if (dimensions < 0.1f)
+            {
+                dimensions = 1f;
+            }
+        }
+    }
+
+    public readonly struct Element
+    {
+        /// <summary>
+        /// Used as an unique value, unique name to the element.
+        /// If no path is given, this needs to be the elements path as well.
+        /// </summary>
+        private readonly string name; // We see this as unique. Might cause issues later on?
+
+        /// <summary>
+        /// Use custom name on the template when user edits HUD
+        /// </summary>
+        private readonly string displayName;
+
+        /// <summary>
+        /// On what layer group should the element be editable. This is as well the parent element where path is related.
+        /// </summary>
+        private readonly Groups group;
+
+        /// <summary>
+        /// Path of the element. Relative to parent.
+        /// </summary>
+        private readonly string locationPath;
+
+        public string Name { get => name; }
+        public string DisplayName { get => displayName; }
+        public Groups Group { get => group; }
+        public string LocationPath { get => locationPath; }
+
+        public Element(string name, Groups group, string locationPath = "", string displayName = "")
+        {
+            this.name = name;
+            this.group = group;
+            this.locationPath = locationPath == "" ? name : locationPath;
+            this.displayName = displayName == "" ? name : displayName;
+        }
+    }
+
+    public enum Groups
+    {
+        HudRoot,
+        Inventory,
+        Other // Is this enough, or should we just specify everything?
+    }
+
+    public enum ParentRoot
+    {
+        Hud,
+        Inventory,
+        HudMessage,
+        TopLeftMessage,
+        Chat,
+        EnemyHud,
+        Store,
+        Menu
+    }
+}

--- a/BetterUI/Patches/ItemIconUpdater.cs
+++ b/BetterUI/Patches/ItemIconUpdater.cs
@@ -1,0 +1,25 @@
+﻿using UnityEngine;
+using UnityEngine.UI;
+
+namespace BetterUI.Patches
+{
+    internal class ItemIconUpdater : MonoBehaviour
+    {
+        private Vector3 origScale;
+        private Image icon;
+
+        public void Setup(Image icon)
+        {
+            this.icon = icon;
+            this.origScale = icon.transform.localScale;
+            IconScaleSize_SettingChanged();
+
+            Main.iconScaleSize.SettingChanged += (_, _) => IconScaleSize_SettingChanged();
+        }
+
+        private void IconScaleSize_SettingChanged()
+        {
+            icon.transform.localScale = origScale * Mathf.Max(Main.iconScaleSize.Value, 0.1f);
+        }
+    }
+}

--- a/BetterUI/Patches/Items.cs
+++ b/BetterUI/Patches/Items.cs
@@ -9,6 +9,24 @@ using UnityEngine.UI;
 
 namespace BetterUI.Patches
 {
+    public static class ElementHelper
+    {
+        public static void UpdateElement(GuiBar durabilityBar, Image icon, ItemDrop.ItemData item)
+        {
+            if (Main.durabilityBarColorPalette.Value != Main.DurabilityBarStyle.Disabled && item.m_shared.m_useDurability)
+            {
+                if (item.m_durability <= 0f)
+                {
+                    // Item has no durability, original code will handle this
+                }
+                else // Item has durability left
+                {
+                    DurabilityBar.UpdateColor(durabilityBar, item.GetDurabilityPercentage());
+                }
+            }
+        }
+    }
+
   static class DurabilityBar
   {
     private static readonly Color[] normal = new Color[]
@@ -32,58 +50,31 @@ namespace BetterUI.Patches
       protanopia
     };
 
-    private static readonly Color[] activeColor = colorArray[Main.durabilityColorPalette.Value] as Color[];
+    private static readonly Color[] activeColor = colorArray[(int)Main.durabilityBarColorPalette.Value] as Color[];
 
-    public static void UpdateColor(InventoryGrid.Element element, float durability)
+    public static void UpdateColor(GuiBar durabilityBar, float durability)
     {
-      element.m_durability.SetValue(durability);
+      durabilityBar.SetValue(durability);
       // Might be to update items colorbar? This is from original code.
-      element.m_durability.ResetColor();
+      durabilityBar.ResetColor();
       // Between 1f - 0f
       switch (durability)
       {
         case float n when (n >= 0.75f):
           // Color green
-          element.m_durability.SetColor(activeColor[0]);
+          durabilityBar.SetColor(activeColor[0]);
           break;
         case float n when (n >= 0.50f):
           // Color yellow
-          element.m_durability.SetColor(activeColor[1]);
+          durabilityBar.SetColor(activeColor[1]);
           break;
         case float n when (n >= 0.25f):
           // Color Orange
-          element.m_durability.SetColor(activeColor[2]);
+          durabilityBar.SetColor(activeColor[2]);
           break;
         case float n when (n >= 0f):
           // Color Red
-          element.m_durability.SetColor(activeColor[3]);
-          break;
-      }
-    }
-
-    public static void UpdateColor(HotkeyBar.ElementData element, float durability)
-    {
-      element.m_durability.SetValue(durability);
-      // Might be to update items colorbar? This is from original code.
-      element.m_durability.ResetColor();
-      // Between 1f - 0f
-      switch (durability)
-      {
-        case float n when (n >= 0.75f):
-          // Color green
-          element.m_durability.SetColor(activeColor[0]);
-          break;
-        case float n when (n >= 0.50f):
-          // Color yellow
-          element.m_durability.SetColor(activeColor[1]);
-          break;
-        case float n when (n >= 0.25f):
-          // Color Orange
-          element.m_durability.SetColor(activeColor[2]);
-          break;
-        case float n when (n >= 0f):
-          // Color Red
-          element.m_durability.SetColor(activeColor[3]);
+          durabilityBar.SetColor(activeColor[3]);
           break;
       }
     }
@@ -115,7 +106,7 @@ namespace BetterUI.Patches
       // Parent size = 64x64, quality size = 20x20, top-right (0,0) -> (-4f,-10f)
       element.m_quality.rectTransform.anchoredPosition = new Vector2(-4f, -6f);
 
-      // TODO: Spawned items might brake this, as they could have 99 stars. 
+      // TODO: Spawned items might break this, as they could have 99 stars. 
       // Possible fix, after x amount switch to: ★x[amount] = ★x99
     }
     public static string HoverText(int quality_lvl)

--- a/BetterUI/Patches/RPG.cs
+++ b/BetterUI/Patches/RPG.cs
@@ -13,8 +13,22 @@ namespace BetterUI.Patches
         private static Color barColor = Color.yellow;
         private static GuiBar _xp_bar = null;
 
-        public static GuiBar Awake(Hud __instance)
+        public static void UpdateLevelProgressPercentage()
         {
+            if(_xp_bar != null)
+            {
+                _xp_bar.SetValue(XP.LevelProgressPercentage);
+            }
+        }
+
+        public static void Create(Hud __instance)
+        {
+            // we've obviously already done this before if it's not null
+            if (_xp_bar != null)
+            {
+                return;
+            }
+
             Transform hudroot = Utils.FindChild(__instance.gameObject.transform, "hudroot");
             GuiBar xp_bar = UnityEngine.Object.Instantiate(Hud.instance.m_stealthBar, hudroot, true);
             xp_bar.m_barImage = Hud.instance.m_stealthBar.m_bar.GetComponent<Image>();
@@ -48,16 +62,20 @@ namespace BetterUI.Patches
             // Render the XP Bar 
             xp_bar.gameObject.SetActive(true);
             _xp_bar = xp_bar;
-
-            return xp_bar;
         }
 
         public static void UpdatePosition()
         {
-            if (_xp_bar == null) return;
-            RectTransform xpRect = (_xp_bar.transform as RectTransform);
-            if (xpRect == null) return;
-            _xp_bar.m_bar.sizeDelta = xpRect.rect.size;
+            if (_xp_bar != null)
+            {
+                // maybe use 'is' syntax, but may not reliable be for unity components (just like ?. doesn't work on monobehaviours)
+                var xpRect = _xp_bar.transform as RectTransform;
+
+                if(xpRect != null)
+                {
+                    _xp_bar.m_bar.sizeDelta = xpRect.rect.size;
+                }
+            }
         }
     }
 
@@ -79,6 +97,7 @@ namespace BetterUI.Patches
                 Debug.LogWarning("Didn't get a player");
                 return;
             }
+
             RPG_Player = player;
 
             UpdatePlayerXP();

--- a/BetterUI/Patches/Skill.cs
+++ b/BetterUI/Patches/Skill.cs
@@ -12,6 +12,11 @@ namespace BetterUI.Patches
             //Debug.Log($"skill level: {skill.m_level}");
             if (skill.m_level >= 100) return;
 
+            if(Main.skipRunningSkillNotifications.Value && skill.m_info.m_skill == Skills.SkillType.Run)
+            {
+                return;
+            }
+
             string notif_str = $"$skill_{ skill.m_info.m_skill.ToString().ToLower()}: {skill.GetLevelPercentage():P2}";
 
             if (Main.extendedXPNotification.Value)

--- a/BetterUI/Patches/TextScaler.cs
+++ b/BetterUI/Patches/TextScaler.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using UnityEngine;
+
+namespace BetterUI.Patches
+{
+    internal class TextScaler : MonoBehaviour
+    {
+        public void Update()
+        {
+            // this sets the total (lossy) X scale to the same as the total lossy Y scale of the text component
+
+            var prevScale = transform.localScale;
+
+            var reverseParentTotalXScale = 1 / transform.parent.lossyScale.x;
+            var parentTotalYScale = transform.parent.lossyScale.y;
+            prevScale.x = reverseParentTotalXScale * parentTotalYScale * prevScale.y;
+
+            this.transform.localScale = prevScale;
+        }
+    }
+}


### PR DESCRIPTION
No need to look at the diffs until #37 is merged

Converted all enum-like int config options into enums, including backwards compatibility (except for bar rotation due to new rotation offsets)

Overhauled general scaling and dimension as well as custom bar rotation system:
- in addition to being able to rotate the custom bars ingame using the new enum config, you can now also rotate them with the mouse wheel in edit mode while not holding down the modifier key. holding down the modifier key and scrolling still changes the scale for any UI element, but additionally while holding down the modifier key moving the mouse horizontally and vertically now changes the X and Y dimension respectively (X dimension support is completely new)
- custom bar text now scales based on Y axis only (that means that the text is no longer distorted when changing only one dimension)
- hotbar and inventory icons now scale ingame through new component
- improved bar update performance by saving in local variables

New features
- added font option for custom bar text and custom food bar duration text
- added option for bee hive hover text like fermenter hover text
- added option to not show running exp notifications

We could apply the new rotation system to all/ more elements, especially the buff and hotkey bar, by moving the rotation data from the new bar enum to the data UI (therefore removing the bar enum before any user ever had them)

Fixes #33
Fixes #34