### PR TITLE
ComfyQuickSlots Compatibility Fix

### DIFF
--- a/BetterUI/GameClasses/HotkeyBar.cs
+++ b/BetterUI/GameClasses/HotkeyBar.cs
@@ -15,24 +15,8 @@ namespace BetterUI.GameClasses
                 return;
             }
 
-            HotkeyBar.ElementData element;
-            float xPos;
-
-            foreach (ItemDrop.ItemData itemData in __instance.m_items)
+            foreach (HotkeyBar.ElementData element in __instance.m_elements)
             {
-                element = null;
-                xPos = itemData.m_gridPos.x;
-
-                if (xPos >= 0 && xPos < __instance.m_elements.Count)
-                {
-                    element = __instance.m_elements[itemData.m_gridPos.x];
-                }
-
-                if (element == null)
-                {
-                    return;
-                }
-
                 // would be better if this could be done reliably in an Awake/ Start, but I'm not in the mood to look for one
                 if (element.m_icon.gameObject.GetComponent<ItemIconUpdater>() == null)
                 {
@@ -40,7 +24,7 @@ namespace BetterUI.GameClasses
                     origScaleComp.Setup(element.m_icon);
                 }
 
-                ElementHelper.UpdateElement(element.m_durability, element.m_icon, itemData);
+                ElementHelper.UpdateElement(element.m_durability, element.m_icon, null);
             }
         }
     }

--- a/BetterUI/Patches/Items.cs
+++ b/BetterUI/Patches/Items.cs
@@ -13,15 +13,16 @@ namespace BetterUI.Patches
     {
         public static void UpdateElement(GuiBar durabilityBar, Image icon, ItemDrop.ItemData item)
         {
-            if (Main.durabilityBarColorPalette.Value != Main.DurabilityBarStyle.Disabled && item.m_shared.m_useDurability)
+            if (Main.durabilityBarColorPalette.Value != Main.DurabilityBarStyle.Disabled && durabilityBar )
             {
-                if (item.m_durability <= 0f)
+                // DurabilityBar.m_value is set to 1 so red flashing bar shows entire length of the icon. Check if color is set to retain value.
+                if (durabilityBar.m_barImage.color.Equals((Mathf.Sin(Time.time * 10f) > 0f) ? Color.red : new Color(0f, 0f, 0f, 0f)))
                 {
                     // Item has no durability, original code will handle this
                 }
                 else // Item has durability left
                 {
-                    DurabilityBar.UpdateColor(durabilityBar, item.GetDurabilityPercentage());
+                    DurabilityBar.UpdateColor(durabilityBar, durabilityBar.m_value / durabilityBar.m_maxValue);
                 }
             }
         }


### PR DESCRIPTION
Hotkeybar compatibility fix for ComfyQuickSlots by relying on Hotkeybar.elementData instead of ItemDrop.ItemData whose index may or may not match item.m_grixPos.x.

Addresses Issue #40 