### PR TITLE
Add eitr support for consumables/recipes

### DIFF
--- a/BetterUI/Patches/Items.cs
+++ b/BetterUI/Patches/Items.cs
@@ -83,7 +83,7 @@ namespace BetterUI.Patches
 
   static class Stars
   {
-    private static Color starColor = new Color(1.0f, 0.85882f, 0.23137f, 1.0f);
+    private static Color starColor = new(1.0f, 0.85882f, 0.23137f, 1.0f);
 
     public static void Draw(InventoryGrid.Element element, int quality_lvl)
     {
@@ -278,10 +278,10 @@ namespace BetterUI.Patches
     {
       if (left)
       {
-        return player.m_leftItem != null ? player.m_leftItem : player.m_hiddenLeftItem; 
+        return player.m_leftItem ?? player.m_hiddenLeftItem; 
       } else
       {
-        return player.m_rightItem != null ? player.m_rightItem : player.m_hiddenRightItem;
+        return player.m_rightItem ?? player.m_hiddenRightItem;
       }
 
     }
@@ -426,9 +426,12 @@ namespace BetterUI.Patches
           {
             if (_item.m_shared.m_food > 0f)
             {
-              _sb.AppendFormat("\n$item_food_health: <color=orange>{0}</color>", _item.m_shared.m_food);
-              _sb.AppendFormat("\n$item_food_stamina: <color=orange>{0}</color>", _item.m_shared.m_foodStamina);
-              _sb.AppendFormat("\n$item_food_duration: <color=orange>{0}s</color>", _item.m_shared.m_foodBurnTime);
+              _sb.AppendFormat("\n$item_food_health: <color=red>{0}</color>", _item.m_shared.m_food);
+              _sb.AppendFormat("\n$item_food_stamina: <color=yellow>{0}</color>", _item.m_shared.m_foodStamina);
+              if (_item.m_shared.m_foodEitr > 0f) {
+                _sb.AppendFormat("\n$item_food_eitr: <color=cyan>{0}</color>", _item.m_shared.m_foodEitr);
+              }
+              _sb.AppendFormat("\n$item_food_duration: <color=orange>{0}s ({1}m)</color>", _item.m_shared.m_foodBurnTime, (_item.m_shared.m_foodBurnTime/60));
               _sb.AppendFormat("\n$item_food_regen: <color=orange>{0} hp/tick</color>", _item.m_shared.m_foodRegen);
             }
             string statusEffectTooltip = _item.GetStatusEffectTooltip(qualityLevel, skillLevel);


### PR DESCRIPTION
Fixes #42 

1. Conditionally adds Eitr information to Consumables if they give Eitr
2. Also colors Health(red)/Stamina(yellow)/Eitr(cyan) values
3. Also adds a minute conversion to the total duration of an item

### Images!

1. ![image](https://user-images.githubusercontent.com/311365/210195475-6c7d5a97-5e9a-4a9f-bfbe-fd4afe7bb61c.png)
2. ![image](https://user-images.githubusercontent.com/311365/210195486-a4a67f01-338b-4104-801d-cd58e8021dce.png)
3. ![image](https://user-images.githubusercontent.com/311365/210195503-bf71fd43-dd2a-4ad9-8336-015f1b921935.png)
4. ![image](https://user-images.githubusercontent.com/311365/210195508-7e06202f-40f2-43a4-9102-5eb7528a4650.png)
