### PR TITLE
Required updates for Valheim version 0.216.9

### DIFF
--- a/BetterUI/Changelog.txt
+++ b/BetterUI/Changelog.txt
@@ -1,4 +1,6 @@
-﻿####v2.4.2
+﻿####v2.4.3
+  - Required updates for Valheim version 0.216.9
+####v2.4.2
   - Fix enemy HUD
 #### 2.4.1
   - Resolve inventory related issues (thedefside)

--- a/BetterUI/GameDir.targets
+++ b/BetterUI/GameDir.targets
@@ -2,6 +2,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <GameDir>C:\Program Files (x86)\Steam\steamapps\common\Valheim</GameDir>
+    <GameDir>D:\SteamLibrary\steamapps\common\Valheim</GameDir>
   </PropertyGroup>
 </Project>

--- a/BetterUI/Main.cs
+++ b/BetterUI/Main.cs
@@ -21,7 +21,7 @@ namespace BetterUI
           MODNAME = "BetterUI",
           AUTHOR = "MK",
           GUID = AUTHOR + "_" + MODNAME,
-          VERSION = "2.4.2";
+          VERSION = "2.4.3";
 
         internal static ManualLogSource log;
         internal readonly Harmony harmony;

--- a/BetterUI/Package/manifest.json
+++ b/BetterUI/Package/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "BetterUI_Reforged",
   "description": "Masa's BetterUI mod updated with bug fixes and new features",
-  "version_number": "2.4.2",
+  "version_number": "2.4.3",
   "website_url": "https://github.com/thedefside/BetterUI",
   "dependencies": [
     "denikson-BepInExPack_Valheim-5.4.2100"

--- a/BetterUI/Patches/Menu.cs
+++ b/BetterUI/Patches/Menu.cs
@@ -27,7 +27,7 @@ namespace BetterUI.Patches
     {
       if (menu.m_profiles == null)
       {
-        menu.m_profiles = PlayerProfile.GetAllPlayerProfiles();
+        menu.m_profiles = SaveSystem.GetAllPlayerProfiles();
       }
       if (menu.m_profileIndex >= menu.m_profiles.Count)
       {

--- a/BetterUI/Properties/AssemblyInfo.cs
+++ b/BetterUI/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.4.2.0")]
-[assembly: AssemblyFileVersion("2.4.2.0")]
+[assembly: AssemblyVersion("2.4.3.0")]
+[assembly: AssemblyFileVersion("2.4.3.0")]


### PR DESCRIPTION
It looks like the GetAllPlayerProfiles method has been moved from the PlayerProfile class to the SaveSystem class. I pre-tested the modification on version 0.216.9 and it works fine.